### PR TITLE
Add protein semantics extraction utilities

### DIFF
--- a/nul
+++ b/nul
@@ -1,0 +1,1 @@
+There are 12 orbitals in the unit cell.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyzgraph"
-version = "1.6.14"
+version = "1.6.15"
 description = "Molecular Graph Construction from Cartesian Coordinates."
 authors = [{name = "Alister S. Goodfellow"}]
 readme = "README.md"

--- a/run.out
+++ b/run.out
@@ -1,0 +1,174 @@
+#BIND_OUTPUT version: 3.0
+
+
+
+#---------------------- SYMMETRY ANALYSIS ----------------------
+
+8 Elements are present. They are:
+  1 Inversion Point
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 6, 4 -> 5, 5 -> 4, 6 -> 3, 
+  2 2-Fold Rotation about (1.000,0.000,0.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 4, 4 -> 3, 5 -> 6, 6 -> 5, 
+  3 2-Fold Rotation about (0.000,1.000,0.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 5, 4 -> 6, 5 -> 3, 6 -> 4, 
+  4 2-Fold Rotation about (0.000,0.000,1.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 6, 4 -> 5, 5 -> 4, 6 -> 3, 
+  5 Mirror Plane with normal: (1.000,0.000,0.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 5, 4 -> 6, 5 -> 3, 6 -> 4, 
+  6 Mirror Plane with normal: (0.000,1.000,0.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 4, 4 -> 3, 5 -> 6, 6 -> 5, 
+  7 Mirror Plane with normal: (0.000,0.000,1.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5, 6 -> 6, 
+  8 Identity.
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5, 6 -> 6, 
+
+Here are the  Non-Redundant Elements which are present:
+Inversion Point
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 6, 4 -> 5, 5 -> 4, 6 -> 3, 
+2-Fold Rotation about (1.000,0.000,0.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 4, 4 -> 3, 5 -> 6, 6 -> 5, 
+2-Fold Rotation about (0.000,1.000,0.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 5, 4 -> 6, 5 -> 3, 6 -> 4, 
+2-Fold Rotation about (0.000,0.000,1.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 6, 4 -> 5, 5 -> 4, 6 -> 3, 
+Mirror Plane with normal: (1.000,0.000,0.000)
+   Equivalent Atoms: 1 -> 2, 2 -> 1, 3 -> 5, 4 -> 6, 5 -> 3, 6 -> 4, 
+Mirror Plane with normal: (0.000,1.000,0.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 4, 4 -> 3, 5 -> 6, 6 -> 5, 
+Mirror Plane with normal: (0.000,0.000,1.000)
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5, 6 -> 6, 
+Identity.
+   Equivalent Atoms: 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5, 6 -> 6, 
+
+;-----------------------------------------------------------------
+Allocating approximately     9.42 Kbytes (    0.01 Meg).
+Each matrix is:     0.00 meg.
+
+; Number of orbitals
+#Num_Orbitals: 12
+Error value from Diagonalization (0 is good): 0
+
+#	******* Energies (in eV)  and Occupation Numbers *******
+1:--->  -27.1677  [2.000 Electrons]
+2:--->  -21.1708  [2.000 Electrons]
+3:--->  -16.5213  [2.000 Electrons]
+4:--->  -14.8794  [2.000 Electrons]
+5:--->  -14.5705  [2.000 Electrons]
+6:--->  -13.2176  [2.000 Electrons]
+7:--->  -8.23815  [0.000 Electrons]
+8:--->   8.30511  [0.000 Electrons]
+9:--->   12.1106  [0.000 Electrons]
+10:--->     19.68  [0.000 Electrons]
+11:--->   30.9718  [0.000 Electrons]
+12:--->   61.3483  [0.000 Electrons]
+Total_Energy: -215.054
+
+# Characters of wavefunctions with respect to symmetry operations present.
+;              1      2      3      4      5      6      7      8 
+   1:--->  1.000  1.000  1.000  1.000  1.000  1.000  1.000  1.000 
+   2:---> -1.000  1.000 -1.000 -1.000 -1.000  1.000  1.000  1.000 
+   3:---> -1.000 -1.000  1.000 -1.000  1.000 -1.000  1.000  1.000 
+   4:--->  1.000 -1.000 -1.000  1.000 -1.000 -1.000  1.000  1.000 
+   5:--->  1.000  1.000  1.000  1.000  1.000  1.000  1.000  1.000 
+   6:---> -1.000 -1.000 -1.000  1.000  1.000  1.000 -1.000  1.000 
+   7:--->  1.000 -1.000  1.000 -1.000 -1.000  1.000 -1.000  1.000 
+   8:---> -1.000 -1.000  1.000 -1.000  1.000 -1.000  1.000  1.000 
+   9:---> -1.000  1.000 -1.000 -1.000 -1.000  1.000  1.000  1.000 
+  10:--->  1.000 -1.000 -1.000  1.000 -1.000 -1.000  1.000  1.000 
+  11:--->  1.000  1.000  1.000  1.000  1.000  1.000  1.000  1.000 
+  12:---> -1.000  1.000 -1.000 -1.000 -1.000  1.000  1.000  1.000 
+
+;   Reduced Mulliken Overlap Population Matrix for 12.000 electrons:
+
+              1        2        3        4        5        6      
+  1        2.7220    
+  2        1.2780      2.7220    
+  3        0.8326      -0.0708     0.5897    
+  4        0.8326      -0.0708     -0.0556     0.5897    
+  5        -0.0708     0.8326      -0.0115     0.0031      0.5897    
+  6        -0.0708     0.8326      0.0031      -0.0115     -0.0556     0.5897    
+
+;    Net Atomic Charges for 12.000 electrons:
+1 C: -0.122810
+2 C: -0.122810
+3 H: 0.061405
+4 H: 0.061405
+5 H: 0.061405
+6 H: 0.061405
+;      Total Charge is: -0.000000
+
+
+; 		q-q-q-q-q-q-q-q  Charge Matrix q-q-q-q-q-q-q-q
+
+;   Reduced Charge Matrix Independant of Occupation
+      1        2        3        4        5        6        7      
+   1  0.4141  0.2739  0.2699  0.2086  0.3950  0.5000  0.5000
+   2  0.4141  0.2739  0.2699  0.2086  0.3950  0.5000  0.5000
+   3  0.0429  0.1131  0.1151  0.1457  0.0525  0.0000  0.0000
+   4  0.0429  0.1131  0.1151  0.1457  0.0525  0.0000  0.0000
+   5  0.0429  0.1131  0.1151  0.1457  0.0525  0.0000  0.0000
+   6  0.0429  0.1131  0.1151  0.1457  0.0525  0.0000  0.0000
+      8        9        10       11       12     
+   1  0.2301  0.3292  0.2914  0.1909  0.3970
+   2  0.2301  0.3292  0.2914  0.1909  0.3970
+   3  0.1349  0.0854  0.1043  0.1545  0.0515
+   4  0.1349  0.0854  0.1043  0.1545  0.0515
+   5  0.1349  0.0854  0.1043  0.1545  0.0515
+   6  0.1349  0.0854  0.1043  0.1545  0.0515
+
+
+ Sorting 12 crystal orbitals.
+
+
+# ******** Extended Hueckel Parameters ********
+;  FORMAT  quantum number orbital: Hii, <c1>, exponent1, <c2>, <exponent2>
+
+ATOM: C   Atomic number: 6  # Valence Electrons: 4
+	2S:   -21.4000     1.6250
+	2P:   -11.4000     1.6250
+ATOM: H   Atomic number: 1  # Valence Electrons: 1
+	1S:   -13.6000     1.3000
+
+### TOTAL DENSITY OF STATES 
+24 states are present.
+#BEGIN CURVE
+1.000000 -27.167740
+1.000000 -21.170830
+1.000000 -16.521276
+1.000000 -14.879352
+1.000000 -14.570485
+1.000000 -13.217560
+1.000000 -8.238147
+1.000000 8.305111
+1.000000 12.110592
+1.000000 19.680035
+1.000000 30.971760
+1.000000 61.348255
+#END CURVE
+# END OF DOS
+
+
+;  The Fermi Level was determined for 1 K points based on
+;     an ordering of 12 crystal orbitals occupied by 12.000000 electrons
+;      in the unit cell (12.000000 electrons total)
+#Fermi_Energy:  -13.217560
+#Average Energy:  -215.054485 eV
+
+# Atomic Orbital Occupations
+;        s      px      py      pz    dx2-y2    dz2     dxy     dxz     dyz
+1 C  1.1941  0.9718  0.9569  1.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+2 C  1.1941  0.9718  0.9569  1.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+3 H  0.9386  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+4 H  0.9386  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+5 H  0.9386  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+6 H  0.9386  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 
+
+# AVERAGE NET CHARGES
+1 C -0.122810
+2 C -0.122810
+3 H 0.061405
+4 H 0.061405
+5 H 0.061405
+6 H 0.061405
+There are a total of 12.000000 electrons.
+Done!

--- a/src/xyzgraph/__init__.py
+++ b/src/xyzgraph/__init__.py
@@ -19,6 +19,16 @@ from .graph_builders_rdkit_tm import build_graph_rdkit_tm
 from .graph_builders_xtb import build_graph_xtb
 from .nci import NCIAnalyzer, NCIThresholds, detect_ncis
 from .orca_parser import OrcaParseError, parse_orca_output
+from .protein import (
+    ProteinChainSemantics,
+    ProteinConfidenceTier,
+    ProteinExtractionReport,
+    ProteinResidueSemantics,
+    ProteinSemantics,
+    annotate_protein_semantics,
+    protein_semantics_from_dict,
+    protein_semantics_to_dict,
+)
 from .stereo import StereoSummary, annotate_stereo
 from .utils import count_frames_and_atoms, graph_debug_report, graph_to_dict, read_xyz_file
 
@@ -27,7 +37,13 @@ __all__ = [
     "NCIAnalyzer",
     "NCIThresholds",
     "OrcaParseError",
+    "ProteinChainSemantics",
+    "ProteinConfidenceTier",
+    "ProteinExtractionReport",
+    "ProteinResidueSemantics",
+    "ProteinSemantics",
     "StereoSummary",
+    "annotate_protein_semantics",
     "annotate_stereo",
     "build_graph",
     "build_graph_orca",
@@ -42,5 +58,7 @@ __all__ = [
     "graph_to_ascii",
     "graph_to_dict",
     "parse_orca_output",
+    "protein_semantics_from_dict",
+    "protein_semantics_to_dict",
     "read_xyz_file",
 ]

--- a/src/xyzgraph/data_loader.py
+++ b/src/xyzgraph/data_loader.py
@@ -19,6 +19,7 @@ class MolecularData:
     valences: Dict[str, List[int]]
     electrons: Dict[str, int]
     metals: Set[str]
+    sblock_metals: Set[str]
     s2n: Dict[str, int]
     n2s: Dict[int, str]
     electronegativity: Dict[str, float]
@@ -110,8 +111,15 @@ class MolecularData:
             "Li",
             "Na",
             "K",
+            "Rb",
+            "Cs",
+            "Fr",
+            "Be",
             "Mg",
             "Ca",
+            "Sr",
+            "Ba",
+            "Ra",
             "Zn",
             "Sc",
             "Ti",
@@ -162,6 +170,9 @@ class MolecularData:
             "Lu",
         }
 
+        # Common s-block metals (for selector compatibility in downstream tools)
+        sblock_metals = {"Li", "Na", "K", "Rb", "Cs", "Fr", "Be", "Mg", "Ca", "Sr", "Ba", "Ra"}
+
         # Load element mappings
         element_file = data_path / "atom_symbols.json"
         with element_file.open("r", encoding="utf-8") as f:
@@ -199,6 +210,7 @@ class MolecularData:
             valences=expected_valences,
             electrons=valence_electrons,
             metals=metals,
+            sblock_metals=sblock_metals,
             s2n=s2n,
             n2s=n2s,
             electronegativity=electronegativity,

--- a/src/xyzgraph/data_loader.py
+++ b/src/xyzgraph/data_loader.py
@@ -132,6 +132,8 @@ class MolecularData:
             "Sr",
             "Cs",
             "Ba",
+            "Fr",
+            "Ra",
             "Zn",
             "Sc",
             "Ti",
@@ -181,6 +183,9 @@ class MolecularData:
             "Yb",
             "Lu",
         }
+
+        # Common s-block metals (for selector compatibility in downstream tools)
+        sblock_metals = {"Li", "Na", "K", "Rb", "Cs", "Fr", "Be", "Mg", "Ca", "Sr", "Ba", "Ra"}
 
         # Load element mappings
         element_file = data_path / "atom_symbols.json"

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -24,7 +24,9 @@ _ANNOTATION_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 _WATER_RESNAMES: frozenset[str] = frozenset({"HOH", "WAT", "DOD", "H2O", "TIP", "TIP3", "SOL"})
-_ION_RESNAMES: frozenset[str] = frozenset({"NA", "K", "CA", "MG", "ZN", "CL", "FE", "CU", "MN", "CO", "NI", "SO4", "PO4"})
+_ION_RESNAMES: frozenset[str] = frozenset(
+    {"NA", "K", "CA", "MG", "ZN", "CL", "FE", "CU", "MN", "CO", "NI", "SO4", "PO4"}
+)
 _SS_INFERENCE = {
     "helix_torsion_min": 20.0,
     "helix_torsion_max": 105.0,
@@ -134,14 +136,14 @@ def _normalize_annotations(raw: Iterable[dict[str, object]] | None, n_atoms: int
         return None
 
     out: list[dict[str, object]] = []
-    for idx, row in enumerate(rows):
-        row = row or {}
-        rec = str(_pick_annotation_value(row, "record_type", "ATOM")).strip().upper() or "ATOM"
-        atom_name = str(_pick_annotation_value(row, "atom_name", "")).strip()
-        res_name = str(_pick_annotation_value(row, "res_name", "UNK")).strip().upper() or "UNK"
-        chain_id = str(_pick_annotation_value(row, "chain_id", "A")).strip() or "A"
-        res_seq = _to_int(_pick_annotation_value(row, "res_seq", idx + 1), default=idx + 1)
-        ss_type = _normalize_ss(_pick_annotation_value(row, "ss_type", "C"))
+    for idx, annotation_row in enumerate(rows):
+        normalized_row = annotation_row or {}
+        rec = str(_pick_annotation_value(normalized_row, "record_type", "ATOM")).strip().upper() or "ATOM"
+        atom_name = str(_pick_annotation_value(normalized_row, "atom_name", "")).strip()
+        res_name = str(_pick_annotation_value(normalized_row, "res_name", "UNK")).strip().upper() or "UNK"
+        chain_id = str(_pick_annotation_value(normalized_row, "chain_id", "A")).strip() or "A"
+        res_seq = _to_int(_pick_annotation_value(normalized_row, "res_seq", idx + 1), default=idx + 1)
+        ss_type = _normalize_ss(_pick_annotation_value(normalized_row, "ss_type", "C"))
 
         out.append(
             {
@@ -174,10 +176,9 @@ def _derive_ss_spans(chains: dict[str, ProteinChainSemantics], ss_type: str) -> 
                 else:
                     spans.append((cid, int(start), int(end)))
                     start = end = res.res_seq
-            else:
-                if start is not None:
-                    spans.append((cid, int(start), int(end)))
-                    start = end = None
+            elif start is not None:
+                spans.append((cid, int(start), int(end)))
+                start = end = None
             prev_seq = res.res_seq
         if start is not None:
             spans.append((cid, int(start), int(end)))
@@ -295,7 +296,10 @@ def _infer_missing_ss_in_chain(graph: nx.Graph, residues: list[ProteinResidueSem
         p1 = anchors[i]
         p2 = anchors[i + 1]
         p3 = anchors[i + 2]
-        assert p0 is not None and p1 is not None and p2 is not None and p3 is not None
+        assert p0 is not None
+        assert p1 is not None
+        assert p2 is not None
+        assert p3 is not None
 
         torsion = _dihedral_degrees(p0, p1, p2, p3)
         abs_torsion = abs(torsion)
@@ -591,7 +595,7 @@ def _extract_heuristic(graph: nx.Graph) -> ProteinSemantics | None:
         n_to_candidates.setdefault(n_atom, []).append(rid)
 
     succ: dict[int, set[int]] = {rid: set() for rid in range(len(candidates))}
-    pred_count: dict[int, int] = {rid: 0 for rid in range(len(candidates))}
+    pred_count: dict[int, int] = dict.fromkeys(range(len(candidates)), 0)
     for rid, (_, _, carbonyl_c) in enumerate(candidates):
         for nb in graph.neighbors(carbonyl_c):
             for nxt in n_to_candidates.get(int(nb), []):
@@ -623,7 +627,9 @@ def _extract_heuristic(graph: nx.Graph) -> ProteinSemantics | None:
         if len(seg) >= 3:
             segments.append(seg)
 
-    remainder = [rid for rid in range(len(candidates)) if rid not in seen_candidates and (succ[rid] or pred_count[rid] > 0)]
+    remainder = [
+        rid for rid in range(len(candidates)) if rid not in seen_candidates and (succ[rid] or pred_count[rid] > 0)
+    ]
     for rid in sorted(remainder):
         seg = _walk(rid, seen_candidates)
         if len(seg) >= 3:

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -1,0 +1,837 @@
+"""Protein semantics extraction for downstream rendering workflows.
+
+This module provides a graph-level, format-agnostic protein semantics layer
+that can be consumed by renderers (e.g. xyzrender) without hard-coding
+format-specific logic into drawing code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Iterable
+
+import networkx as nx
+import numpy as np
+
+_ANNOTATION_ALIASES: dict[str, tuple[str, ...]] = {
+    "record_type": ("record_type", "group_pdb", "pdb_record_type", "_atom_site.group_pdb"),
+    "atom_name": ("atom_name", "auth_atom_id", "label_atom_id", "atomtypes"),
+    "res_name": ("res_name", "auth_comp_id", "label_comp_id", "residuenames"),
+    "res_seq": ("res_seq", "auth_seq_id", "label_seq_id", "residuenumbers"),
+    "chain_id": ("chain_id", "auth_asym_id", "label_asym_id", "chainids"),
+    "ss_type": ("ss_type", "secondary_structure"),
+}
+
+_WATER_RESNAMES: frozenset[str] = frozenset({"HOH", "WAT", "DOD", "H2O", "TIP", "TIP3", "SOL"})
+_ION_RESNAMES: frozenset[str] = frozenset({"NA", "K", "CA", "MG", "ZN", "CL", "FE", "CU", "MN", "CO", "NI", "SO4", "PO4"})
+_SS_INFERENCE = {
+    "helix_torsion_min": 20.0,
+    "helix_torsion_max": 105.0,
+    "helix_d3_min": 4.7,
+    "helix_d3_max": 6.8,
+    "helix_d2_min": 5.0,
+    "helix_d2_max": 6.4,
+    "sheet_abs_torsion_min": 130.0,
+    "sheet_d3_min": 8.0,
+    "sheet_d2_min": 6.1,
+    "bridge_gap": 1,
+    "min_helix_run": 4,
+    "min_sheet_run": 3,
+}
+
+
+class ProteinConfidenceTier(Enum):
+    """Confidence tiers for protein semantics extraction."""
+
+    FULL_RIBBON = "full_ribbon"
+    TRACE_ONLY = "trace_only"
+    INSUFFICIENT = "insufficient"
+
+
+@dataclass
+class ProteinResidueSemantics:
+    """Normalized residue-level protein semantics."""
+
+    res_name: str
+    res_seq: int
+    chain_id: str
+    atom_indices: list[int]
+    ca_index: int | None
+    c_index: int | None
+    o_index: int | None
+    n_index: int | None
+    ss_type: str = "C"
+
+
+@dataclass
+class ProteinChainSemantics:
+    """Ordered residue semantics for a chain."""
+
+    chain_id: str
+    residues: list[ProteinResidueSemantics]
+
+
+@dataclass
+class ProteinSemantics:
+    """Format-agnostic protein semantics used by downstream renderers."""
+
+    chains: dict[str, ProteinChainSemantics]
+    hetatm_indices: set[int]
+    backbone_indices: set[int]
+    sidechain_indices: set[int]
+    helix_spans: list[tuple[str, int, int]]
+    sheet_spans: list[tuple[str, int, int]]
+    ligand_indices: set[int] = field(default_factory=set)
+    water_indices: set[int] = field(default_factory=set)
+    ion_indices: set[int] = field(default_factory=set)
+    confidence_tier: ProteinConfidenceTier = ProteinConfidenceTier.FULL_RIBBON
+    confidence_reasons: list[str] = field(default_factory=list)
+    provenance: list[str] = field(default_factory=list)
+    trace_chains: dict[str, list[int]] = field(default_factory=dict)
+
+
+@dataclass
+class ProteinExtractionReport:
+    """Structured result from protein semantics extraction."""
+
+    semantics: ProteinSemantics
+    confidence_tier: ProteinConfidenceTier
+    confidence_reasons: list[str]
+
+
+def _normalize_ss(value: object) -> str:
+    ss = str(value or "C").strip().upper()
+    return ss if ss in {"H", "E", "C"} else "C"
+
+
+def _to_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _pick_annotation_value(row: dict[str, object], key: str, default: object) -> object:
+    aliases = _ANNOTATION_ALIASES.get(key, (key,))
+    for alias in aliases:
+        if alias not in row:
+            continue
+        value = row.get(alias)
+        if value is None:
+            continue
+        if isinstance(value, str) and value.strip() in {"", ".", "?"}:
+            continue
+        return value
+    return default
+
+
+def _normalize_annotations(raw: Iterable[dict[str, object]] | None, n_atoms: int) -> list[dict[str, object]] | None:
+    if raw is None:
+        return None
+    rows = list(raw)
+    if len(rows) != n_atoms:
+        return None
+
+    out: list[dict[str, object]] = []
+    for idx, row in enumerate(rows):
+        row = row or {}
+        rec = str(_pick_annotation_value(row, "record_type", "ATOM")).strip().upper() or "ATOM"
+        atom_name = str(_pick_annotation_value(row, "atom_name", "")).strip()
+        res_name = str(_pick_annotation_value(row, "res_name", "UNK")).strip().upper() or "UNK"
+        chain_id = str(_pick_annotation_value(row, "chain_id", "A")).strip() or "A"
+        res_seq = _to_int(_pick_annotation_value(row, "res_seq", idx + 1), default=idx + 1)
+        ss_type = _normalize_ss(_pick_annotation_value(row, "ss_type", "C"))
+
+        out.append(
+            {
+                "record_type": "HETATM" if rec == "HETATM" else "ATOM",
+                "atom_name": atom_name,
+                "res_name": res_name,
+                "chain_id": chain_id,
+                "res_seq": res_seq,
+                "ss_type": ss_type,
+            }
+        )
+
+    return out
+
+
+def _derive_ss_spans(chains: dict[str, ProteinChainSemantics], ss_type: str) -> list[tuple[str, int, int]]:
+    spans: list[tuple[str, int, int]] = []
+    for cid in sorted(chains):
+        residues = chains[cid].residues
+        if not residues:
+            continue
+        start = end = None
+        prev_seq = None
+        for res in residues:
+            if res.ss_type == ss_type:
+                if start is None:
+                    start = end = res.res_seq
+                elif prev_seq is not None and res.res_seq == prev_seq + 1:
+                    end = res.res_seq
+                else:
+                    spans.append((cid, int(start), int(end)))
+                    start = end = res.res_seq
+            else:
+                if start is not None:
+                    spans.append((cid, int(start), int(end)))
+                    start = end = None
+            prev_seq = res.res_seq
+        if start is not None:
+            spans.append((cid, int(start), int(end)))
+    return spans
+
+
+def _node_position(graph: nx.Graph, node_id: int) -> tuple[float, float, float] | None:
+    node = graph.nodes[node_id]
+    pos = node.get("position", node.get("pos"))
+    if pos is None:
+        return None
+    try:
+        x, y, z = float(pos[0]), float(pos[1]), float(pos[2])
+    except Exception:
+        return None
+    return (x, y, z)
+
+
+def _anchor_position(graph: nx.Graph, residue: ProteinResidueSemantics) -> tuple[float, float, float] | None:
+    for idx in (residue.ca_index, residue.n_index, residue.c_index):
+        if idx is None:
+            continue
+        pos = _node_position(graph, idx)
+        if pos is not None:
+            return pos
+    return None
+
+
+def _dihedral_degrees(
+    p0: tuple[float, float, float],
+    p1: tuple[float, float, float],
+    p2: tuple[float, float, float],
+    p3: tuple[float, float, float],
+) -> float:
+    a = np.asarray(p0, dtype=float)
+    b = np.asarray(p1, dtype=float)
+    c = np.asarray(p2, dtype=float)
+    d = np.asarray(p3, dtype=float)
+    b0 = a - b
+    b1 = c - b
+    b2 = d - c
+    n = np.linalg.norm(b1)
+    if n <= 1.0e-12:
+        return 0.0
+    b1n = b1 / n
+    v = b0 - np.dot(b0, b1n) * b1n
+    w = b2 - np.dot(b2, b1n) * b1n
+    x = float(np.dot(v, w))
+    y = float(np.dot(np.cross(b1n, v), w))
+    return float(np.degrees(np.arctan2(y, x)))
+
+
+def _distance(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return float(np.linalg.norm(np.asarray(a, dtype=float) - np.asarray(b, dtype=float)))
+
+
+def _bridge_gaps(labels: list[str], symbol: str, max_gap: int, locked: list[bool]) -> None:
+    n = len(labels)
+    i = 0
+    while i < n:
+        if labels[i] != symbol:
+            i += 1
+            continue
+        j = i
+        while j < n and labels[j] == symbol:
+            j += 1
+        k = j
+        while k < n and labels[k] == "C" and not locked[k]:
+            k += 1
+        gap = k - j
+        if 0 < gap <= max_gap and k < n and labels[k] == symbol:
+            for u in range(j, k):
+                labels[u] = symbol
+        i = k
+
+
+def _trim_short_runs(labels: list[str], symbol: str, min_len: int, locked: list[bool]) -> None:
+    n = len(labels)
+    i = 0
+    while i < n:
+        if labels[i] != symbol:
+            i += 1
+            continue
+        j = i
+        has_locked = False
+        while j < n and labels[j] == symbol:
+            has_locked = has_locked or locked[j]
+            j += 1
+        if not has_locked and (j - i) < min_len:
+            for u in range(i, j):
+                labels[u] = "C"
+        i = j
+
+
+def _infer_missing_ss_in_chain(graph: nx.Graph, residues: list[ProteinResidueSemantics]) -> list[str]:
+    n = len(residues)
+    if n < 4:
+        return ["C"] * n
+
+    anchors = [_anchor_position(graph, r) for r in residues]
+    helix_votes = [0] * n
+    sheet_votes = [0] * n
+
+    for i in range(1, n - 2):
+        win = residues[i - 1 : i + 3]
+        if any(anchors[idx] is None for idx in (i - 1, i, i + 1, i + 2)):
+            continue
+        if not (
+            win[1].res_seq == win[0].res_seq + 1
+            and win[2].res_seq == win[1].res_seq + 1
+            and win[3].res_seq == win[2].res_seq + 1
+        ):
+            continue
+        p0 = anchors[i - 1]
+        p1 = anchors[i]
+        p2 = anchors[i + 1]
+        p3 = anchors[i + 2]
+        assert p0 is not None and p1 is not None and p2 is not None and p3 is not None
+
+        torsion = _dihedral_degrees(p0, p1, p2, p3)
+        abs_torsion = abs(torsion)
+        d3 = _distance(p0, p3)
+        d2 = _distance(p0, p2)
+
+        helix_like = (
+            _SS_INFERENCE["helix_torsion_min"] <= torsion <= _SS_INFERENCE["helix_torsion_max"]
+            and _SS_INFERENCE["helix_d3_min"] <= d3 <= _SS_INFERENCE["helix_d3_max"]
+            and _SS_INFERENCE["helix_d2_min"] <= d2 <= _SS_INFERENCE["helix_d2_max"]
+        )
+        sheet_like = (
+            abs_torsion >= _SS_INFERENCE["sheet_abs_torsion_min"]
+            and d3 >= _SS_INFERENCE["sheet_d3_min"]
+            and d2 >= _SS_INFERENCE["sheet_d2_min"]
+        )
+
+        if helix_like and not sheet_like:
+            helix_votes[i] += 1
+            helix_votes[i + 1] += 1
+        elif sheet_like and not helix_like:
+            sheet_votes[i] += 1
+            sheet_votes[i + 1] += 1
+
+    inferred = ["C"] * n
+    for i in range(n):
+        h = helix_votes[i]
+        e = sheet_votes[i]
+        if h == 0 and e == 0:
+            continue
+        inferred[i] = "H" if h >= e else "E"
+    return inferred
+
+
+def _supplement_secondary_structure(graph: nx.Graph, semantics: ProteinSemantics) -> int:
+    inferred_residues = 0
+    explicit_has_ss = any(res.ss_type in {"H", "E"} for chain in semantics.chains.values() for res in chain.residues)
+
+    for chain in semantics.chains.values():
+        residues = chain.residues
+        if not residues:
+            continue
+        locked = [r.ss_type in {"H", "E"} for r in residues]
+        if all(locked):
+            continue
+        inferred = _infer_missing_ss_in_chain(graph, residues)
+        labels = [r.ss_type if r.ss_type in {"H", "E"} else inferred[i] for i, r in enumerate(residues)]
+
+        _bridge_gaps(labels, "H", int(_SS_INFERENCE["bridge_gap"]), locked)
+        _bridge_gaps(labels, "E", int(_SS_INFERENCE["bridge_gap"]), locked)
+        _trim_short_runs(labels, "H", int(_SS_INFERENCE["min_helix_run"]), locked)
+        _trim_short_runs(labels, "E", int(_SS_INFERENCE["min_sheet_run"]), locked)
+
+        for i, res in enumerate(residues):
+            if res.ss_type != "C":
+                continue
+            if labels[i] in {"H", "E"}:
+                res.ss_type = labels[i]
+                inferred_residues += 1
+
+    semantics.helix_spans = _derive_ss_spans(semantics.chains, "H")
+    semantics.sheet_spans = _derive_ss_spans(semantics.chains, "E")
+    inferred_any = inferred_residues > 0
+    if inferred_any:
+        if "inferred" not in semantics.provenance:
+            semantics.provenance.append("inferred")
+        if explicit_has_ss:
+            msg = "secondary structure supplemented by geometry inference"
+        else:
+            msg = "secondary structure inferred from geometry"
+        if msg not in semantics.confidence_reasons:
+            semantics.confidence_reasons.append(msg)
+    return inferred_residues
+
+
+def _is_peptide_residue(atom_names: set[str], res_name: str) -> bool:
+    if res_name in _WATER_RESNAMES or res_name in _ION_RESNAMES:
+        return False
+    # Conservative: require canonical peptide backbone naming to avoid ligand leakage.
+    return {"N", "CA", "C"}.issubset(atom_names)
+
+
+def _extract_from_annotations(
+    graph: nx.Graph,
+    annotations: list[dict[str, object]],
+    *,
+    provenance: str,
+) -> ProteinSemantics | None:
+    n_atoms = graph.number_of_nodes()
+    if n_atoms == 0:
+        return None
+
+    residues: dict[tuple[str, int, str], list[int]] = {}
+    residue_order: list[tuple[str, int, str]] = []
+    residue_names: dict[tuple[str, int, str], set[str]] = {}
+    residue_ss: dict[tuple[str, int, str], str] = {}
+
+    hetatm_indices: set[int] = set()
+    ligand_indices: set[int] = set()
+    water_indices: set[int] = set()
+    ion_indices: set[int] = set()
+
+    for idx, row in enumerate(annotations):
+        rec = str(row["record_type"])
+        atom_name = str(row["atom_name"]).upper().strip()
+        res_name = str(row["res_name"]).upper().strip() or "UNK"
+        chain_id = str(row["chain_id"]).strip() or "A"
+        res_seq = _to_int(row["res_seq"], default=idx + 1)
+        ss_type = _normalize_ss(row["ss_type"])
+
+        if rec == "HETATM":
+            hetatm_indices.add(idx)
+            if res_name in _WATER_RESNAMES:
+                water_indices.add(idx)
+            elif res_name in _ION_RESNAMES:
+                ion_indices.add(idx)
+            else:
+                ligand_indices.add(idx)
+            continue
+
+        key = (chain_id, int(res_seq), res_name)
+        if key not in residues:
+            residues[key] = []
+            residue_order.append(key)
+            residue_names[key] = set()
+            residue_ss[key] = ss_type
+        residues[key].append(idx)
+        if atom_name:
+            residue_names[key].add(atom_name)
+        # Keep first provided SS label for deterministic behavior.
+
+    if not residues:
+        return None
+
+    chains_raw: dict[str, list[ProteinResidueSemantics]] = {}
+    backbone_indices: set[int] = set()
+    protein_atoms: set[int] = set()
+
+    for chain_id, res_seq, res_name in residue_order:
+        idxs = residues[(chain_id, res_seq, res_name)]
+        names = residue_names[(chain_id, res_seq, res_name)]
+
+        ca_index = c_index = o_index = n_index = None
+        for idx in idxs:
+            atom_name = str(annotations[idx]["atom_name"]).upper().strip()
+            if atom_name == "CA":
+                ca_index = idx
+                backbone_indices.add(idx)
+            elif atom_name == "C":
+                c_index = idx
+                backbone_indices.add(idx)
+            elif atom_name == "N":
+                n_index = idx
+                backbone_indices.add(idx)
+            elif atom_name in {"O", "OXT"}:
+                if atom_name == "O" and o_index is None:
+                    o_index = idx
+                backbone_indices.add(idx)
+
+        has_trace_anchor = ca_index is not None or (n_index is not None and c_index is not None)
+        if not has_trace_anchor or not _is_peptide_residue(names, res_name):
+            if res_name in _WATER_RESNAMES:
+                water_indices.update(idxs)
+            elif res_name in _ION_RESNAMES:
+                ion_indices.update(idxs)
+            else:
+                ligand_indices.update(idxs)
+            continue
+
+        residue = ProteinResidueSemantics(
+            res_name=res_name,
+            res_seq=int(res_seq),
+            chain_id=chain_id,
+            atom_indices=list(idxs),
+            ca_index=ca_index,
+            c_index=c_index,
+            o_index=o_index,
+            n_index=n_index,
+            ss_type=residue_ss[(chain_id, res_seq, res_name)],
+        )
+        chains_raw.setdefault(chain_id, []).append(residue)
+        protein_atoms.update(idxs)
+
+    # Require chain continuity signal: at least 2 protein-like residues per chain.
+    chains: dict[str, ProteinChainSemantics] = {}
+    for cid, residues_list in chains_raw.items():
+        ordered = sorted(residues_list, key=lambda r: (r.res_seq, r.atom_indices[0] if r.atom_indices else -1))
+        if len(ordered) < 2:
+            continue
+        chains[cid] = ProteinChainSemantics(chain_id=cid, residues=ordered)
+
+    if not chains:
+        return None
+
+    protein_atoms = {idx for chain in chains.values() for res in chain.residues for idx in res.atom_indices}
+    sidechain_indices = protein_atoms - backbone_indices
+
+    # In metadata-driven inputs without HETATM annotations (e.g. MOL2), treat
+    # non-protein residues as ligand only when a protein partition exists.
+    for idx in range(n_atoms):
+        if idx in protein_atoms or idx in hetatm_indices or idx in water_indices or idx in ion_indices:
+            continue
+        ligand_indices.add(idx)
+
+    trace_chains: dict[str, list[int]] = {}
+    for cid, chain in chains.items():
+        trace: list[int] = []
+        for res in chain.residues:
+            ai = res.ca_index if res.ca_index is not None else (res.n_index if res.n_index is not None else res.c_index)
+            if ai is not None:
+                trace.append(ai)
+        if len(trace) >= 2:
+            trace_chains[cid] = trace
+
+    semantics = ProteinSemantics(
+        chains=chains,
+        hetatm_indices=hetatm_indices,
+        backbone_indices=backbone_indices,
+        sidechain_indices=sidechain_indices,
+        helix_spans=_derive_ss_spans(chains, "H"),
+        sheet_spans=_derive_ss_spans(chains, "E"),
+        ligand_indices=ligand_indices,
+        water_indices=water_indices,
+        ion_indices=ion_indices,
+        confidence_tier=ProteinConfidenceTier.FULL_RIBBON,
+        confidence_reasons=[f"{provenance} annotations parsed"],
+        provenance=[provenance],
+        trace_chains=trace_chains,
+    )
+    has_ca = any(res.ca_index is not None for chain in chains.values() for res in chain.residues)
+    inferred_count = _supplement_secondary_structure(graph, semantics)
+    has_ss = any(res.ss_type in {"H", "E"} for chain in chains.values() for res in chain.residues)
+
+    if not has_ca:
+        semantics.confidence_tier = ProteinConfidenceTier.TRACE_ONLY
+        semantics.confidence_reasons.append("CA atoms missing; downgraded to TRACE_ONLY")
+    elif not has_ss and inferred_count == 0:
+        semantics.confidence_reasons.append("no explicit helix/sheet labels; loops-only ribbon")
+
+    return semantics
+
+
+def _extract_heuristic(graph: nx.Graph) -> ProteinSemantics | None:
+    """Topology-first fallback used only when explicit protein intent is set."""
+    node_ids = sorted(graph.nodes())
+    if not node_ids:
+        return None
+
+    components = sorted(nx.connected_components(graph), key=lambda c: (-len(c), min(c)))
+    if not components:
+        return None
+
+    largest = set(components[0])
+    if len(largest) < 12:
+        return None
+
+    symbols = {n: str(graph.nodes[n].get("symbol", "")).upper() for n in largest}
+    peptide_like = [n for n in largest if symbols.get(n, "") in {"C", "N", "O", "S"}]
+    if len(peptide_like) < 12:
+        return None
+
+    carbonyl_carbons: set[int] = set()
+    for nid in peptide_like:
+        if symbols.get(nid) != "C":
+            continue
+        if any(symbols.get(nb, "") == "O" for nb in graph.neighbors(nid) if nb in largest):
+            carbonyl_carbons.add(int(nid))
+
+    # Candidate CA-like sites with local peptide-like chemistry:
+    # - bonded to at least one N
+    # - bonded to a carbonyl carbon (C bonded to O)
+    candidates: list[tuple[int, int, int]] = []  # (ca_atom, amide_n, carbonyl_c)
+    for nid in sorted(peptide_like):
+        if symbols.get(nid) != "C":
+            continue
+        n_neigh = sorted(int(nb) for nb in graph.neighbors(nid) if nb in largest and symbols.get(nb, "") == "N")
+        c_neigh = sorted(
+            int(nb)
+            for nb in graph.neighbors(nid)
+            if nb in largest and int(nb) in carbonyl_carbons and int(nb) != int(nid)
+        )
+        if not n_neigh or not c_neigh:
+            continue
+        candidates.append((int(nid), n_neigh[0], c_neigh[0]))
+
+    if len(candidates) < 3:
+        return None
+
+    # Build peptide-link graph between candidate residues:
+    # residue i -> residue j when carbonyl(i) bonds to amide-N(j).
+    n_to_candidates: dict[int, list[int]] = {}
+    for rid, (_, n_atom, _) in enumerate(candidates):
+        n_to_candidates.setdefault(n_atom, []).append(rid)
+
+    succ: dict[int, set[int]] = {rid: set() for rid in range(len(candidates))}
+    pred_count: dict[int, int] = {rid: 0 for rid in range(len(candidates))}
+    for rid, (_, _, carbonyl_c) in enumerate(candidates):
+        for nb in graph.neighbors(carbonyl_c):
+            for nxt in n_to_candidates.get(int(nb), []):
+                if nxt == rid or nxt in succ[rid]:
+                    continue
+                succ[rid].add(nxt)
+                pred_count[nxt] += 1
+
+    def _walk(start: int, seen: set[int]) -> list[int]:
+        seg: list[int] = []
+        cur = start
+        while True:
+            if cur in seen:
+                break
+            seen.add(cur)
+            seg.append(candidates[cur][0])
+            next_nodes = [nxt for nxt in sorted(succ[cur]) if nxt not in seen]
+            if not next_nodes:
+                break
+            cur = next_nodes[0]
+        return seg
+
+    seen_candidates: set[int] = set()
+    segments: list[list[int]] = []
+
+    starts = [rid for rid in range(len(candidates)) if pred_count[rid] == 0 and succ[rid]]
+    for rid in sorted(starts):
+        seg = _walk(rid, seen_candidates)
+        if len(seg) >= 3:
+            segments.append(seg)
+
+    remainder = [rid for rid in range(len(candidates)) if rid not in seen_candidates and (succ[rid] or pred_count[rid] > 0)]
+    for rid in sorted(remainder):
+        seg = _walk(rid, seen_candidates)
+        if len(seg) >= 3:
+            segments.append(seg)
+
+    if not segments:
+        return None
+
+    segments.sort(key=lambda seg: (seg[0], len(seg)))
+    chain_ids: list[str] = [chr(ord("A") + i) if i < 26 else f"C{i + 1}" for i in range(len(segments))]
+
+    chains: dict[str, ProteinChainSemantics] = {}
+    trace_chains: dict[str, list[int]] = {}
+    backbone_indices: set[int] = set()
+    for cid, trace in zip(chain_ids, segments, strict=False):
+        residues = [
+            ProteinResidueSemantics(
+                res_name="UNK",
+                res_seq=i,
+                chain_id=cid,
+                atom_indices=[idx],
+                ca_index=idx,
+                c_index=None,
+                o_index=None,
+                n_index=None,
+                ss_type="C",
+            )
+            for i, idx in enumerate(trace, start=1)
+        ]
+        chains[cid] = ProteinChainSemantics(chain_id=cid, residues=residues)
+        trace_chains[cid] = list(trace)
+        backbone_indices.update(trace)
+
+    ligand_indices: set[int] = set()
+    for comp in components[1:]:
+        ligand_indices.update(int(n) for n in comp)
+
+    return ProteinSemantics(
+        chains=chains,
+        hetatm_indices=set(),
+        backbone_indices=backbone_indices,
+        sidechain_indices={int(n) for n in peptide_like if int(n) not in backbone_indices},
+        helix_spans=[],
+        sheet_spans=[],
+        ligand_indices=ligand_indices,
+        water_indices=set(),
+        ion_indices=set(),
+        confidence_tier=ProteinConfidenceTier.TRACE_ONLY,
+        confidence_reasons=["graph-only heuristic trace from peptide-link topology"],
+        provenance=["heuristic"],
+        trace_chains=trace_chains,
+    )
+
+
+def protein_semantics_to_dict(semantics: ProteinSemantics) -> dict[str, object]:
+    """Serialize :class:`ProteinSemantics` to a graph-storable dictionary."""
+    chain_payload: dict[str, dict[str, object]] = {}
+    for cid, chain in semantics.chains.items():
+        chain_payload[cid] = {
+            "chain_id": chain.chain_id,
+            "residues": [asdict(res) for res in chain.residues],
+        }
+    return {
+        "chains": chain_payload,
+        "hetatm_indices": sorted(semantics.hetatm_indices),
+        "backbone_indices": sorted(semantics.backbone_indices),
+        "sidechain_indices": sorted(semantics.sidechain_indices),
+        "helix_spans": [list(span) for span in semantics.helix_spans],
+        "sheet_spans": [list(span) for span in semantics.sheet_spans],
+        "ligand_indices": sorted(semantics.ligand_indices),
+        "water_indices": sorted(semantics.water_indices),
+        "ion_indices": sorted(semantics.ion_indices),
+        "confidence_tier": semantics.confidence_tier.value,
+        "confidence_reasons": list(semantics.confidence_reasons),
+        "provenance": list(semantics.provenance),
+        "trace_chains": {cid: list(idxs) for cid, idxs in semantics.trace_chains.items()},
+    }
+
+
+def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
+    """Deserialize graph payload into :class:`ProteinSemantics`."""
+    raw_chains = payload.get("chains", {})
+    chains: dict[str, ProteinChainSemantics] = {}
+    if isinstance(raw_chains, dict):
+        for cid, chain_obj in raw_chains.items():
+            if not isinstance(chain_obj, dict):
+                continue
+            residues_obj = chain_obj.get("residues", [])
+            residues: list[ProteinResidueSemantics] = []
+            if isinstance(residues_obj, list):
+                for r in residues_obj:
+                    if not isinstance(r, dict):
+                        continue
+                    residues.append(
+                        ProteinResidueSemantics(
+                            res_name=str(r.get("res_name", "UNK")),
+                            res_seq=_to_int(r.get("res_seq", 0), 0),
+                            chain_id=str(r.get("chain_id", cid)),
+                            atom_indices=[int(x) for x in r.get("atom_indices", [])],
+                            ca_index=(None if r.get("ca_index") is None else int(r["ca_index"])),
+                            c_index=(None if r.get("c_index") is None else int(r["c_index"])),
+                            o_index=(None if r.get("o_index") is None else int(r["o_index"])),
+                            n_index=(None if r.get("n_index") is None else int(r["n_index"])),
+                            ss_type=_normalize_ss(r.get("ss_type", "C")),
+                        )
+                    )
+            chains[str(cid)] = ProteinChainSemantics(chain_id=str(chain_obj.get("chain_id", cid)), residues=residues)
+
+    confidence_raw = str(payload.get("confidence_tier", ProteinConfidenceTier.INSUFFICIENT.value))
+    try:
+        confidence = ProteinConfidenceTier(confidence_raw)
+    except ValueError:
+        confidence = ProteinConfidenceTier.INSUFFICIENT
+
+    return ProteinSemantics(
+        chains=chains,
+        hetatm_indices={int(x) for x in payload.get("hetatm_indices", [])},
+        backbone_indices={int(x) for x in payload.get("backbone_indices", [])},
+        sidechain_indices={int(x) for x in payload.get("sidechain_indices", [])},
+        helix_spans=[(str(c), int(s), int(e)) for c, s, e in payload.get("helix_spans", [])],
+        sheet_spans=[(str(c), int(s), int(e)) for c, s, e in payload.get("sheet_spans", [])],
+        ligand_indices={int(x) for x in payload.get("ligand_indices", [])},
+        water_indices={int(x) for x in payload.get("water_indices", [])},
+        ion_indices={int(x) for x in payload.get("ion_indices", [])},
+        confidence_tier=confidence,
+        confidence_reasons=[str(x) for x in payload.get("confidence_reasons", [])],
+        provenance=[str(x) for x in payload.get("provenance", [])],
+        trace_chains={str(cid): [int(x) for x in idxs] for cid, idxs in payload.get("trace_chains", {}).items()},
+    )
+
+
+def annotate_protein_semantics(
+    graph: nx.Graph,
+    *,
+    atom_annotations: Iterable[dict[str, object]] | None = None,
+    format_hint: str | None = None,
+    protein_requested: bool = False,
+) -> ProteinExtractionReport | None:
+    """Extract and attach protein semantics to ``graph``.
+
+    Parameters
+    ----------
+    graph:
+        Input molecular graph.
+    atom_annotations:
+        Optional canonical per-atom annotations with keys:
+        ``record_type``, ``atom_name``, ``res_name``, ``res_seq``,
+        ``chain_id``, ``ss_type``.
+    format_hint:
+        Optional source-format hint for provenance logging.
+    protein_requested:
+        When ``True``, run graph-only fallback heuristics when metadata
+        extraction is insufficient.
+
+    Returns
+    -------
+    ProteinExtractionReport | None
+        ``None`` when no semantics are available and protein mode was not
+        requested; otherwise a report with extracted semantics.
+    """
+    n_atoms = graph.number_of_nodes()
+    normalized = _normalize_annotations(atom_annotations, n_atoms)
+
+    provenance = "annotations"
+    if format_hint:
+        provenance = f"annotations:{format_hint.lower()}"
+
+    semantics: ProteinSemantics | None = None
+    if normalized is not None:
+        semantics = _extract_from_annotations(graph, normalized, provenance=provenance)
+
+    if semantics is None and protein_requested:
+        semantics = _extract_heuristic(graph)
+
+    if semantics is None:
+        if not protein_requested:
+            return None
+        semantics = ProteinSemantics(
+            chains={},
+            hetatm_indices=set(),
+            backbone_indices=set(),
+            sidechain_indices=set(),
+            helix_spans=[],
+            sheet_spans=[],
+            ligand_indices=set(),
+            water_indices=set(),
+            ion_indices=set(),
+            confidence_tier=ProteinConfidenceTier.INSUFFICIENT,
+            confidence_reasons=["insufficient metadata and weak graph-only signal"],
+            provenance=["none"],
+            trace_chains={},
+        )
+
+    graph.graph["protein_semantics"] = protein_semantics_to_dict(semantics)
+    return ProteinExtractionReport(
+        semantics=semantics,
+        confidence_tier=semantics.confidence_tier,
+        confidence_reasons=list(semantics.confidence_reasons),
+    )
+
+
+__all__ = [
+    "ProteinChainSemantics",
+    "ProteinConfidenceTier",
+    "ProteinExtractionReport",
+    "ProteinResidueSemantics",
+    "ProteinSemantics",
+    "annotate_protein_semantics",
+    "protein_semantics_from_dict",
+    "protein_semantics_to_dict",
+]

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Iterable
+from typing import Iterable, SupportsIndex, SupportsInt
 
 import networkx as nx
 import numpy as np
@@ -108,10 +108,71 @@ def _normalize_ss(value: object) -> str:
 
 
 def _to_int(value: object, default: int = 0) -> int:
+    if not isinstance(value, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+        return default
     try:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _to_int_set(value: object) -> set[int]:
+    if not isinstance(value, list):
+        return set()
+    out: set[int] = set()
+    for item in value:
+        if isinstance(item, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+            try:
+                out.add(int(item))
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _to_str_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _to_spans(value: object) -> list[tuple[str, int, int]]:
+    if not isinstance(value, list):
+        return []
+    spans: list[tuple[str, int, int]] = []
+    for entry in value:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 3:
+            continue
+        c, s, e = entry
+        if not isinstance(s, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+            continue
+        if not isinstance(e, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+            continue
+        try:
+            s_val = int(s)
+            e_val = int(e)
+        except (TypeError, ValueError):
+            continue
+        spans.append((str(c), s_val, e_val))
+    return spans
+
+
+def _to_trace_chains(value: object) -> dict[str, list[int]]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, list[int]] = {}
+    for cid, idxs in value.items():
+        if not isinstance(idxs, list):
+            continue
+        chain: list[int] = []
+        for item in idxs:
+            if not isinstance(item, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+                continue
+            try:
+                chain.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        out[str(cid)] = chain
+    return out
 
 
 def _pick_annotation_value(row: dict[str, object], key: str, default: object) -> object:
@@ -174,13 +235,16 @@ def _derive_ss_spans(chains: dict[str, ProteinChainSemantics], ss_type: str) -> 
                 elif prev_seq is not None and res.res_seq == prev_seq + 1:
                     end = res.res_seq
                 else:
+                    assert end is not None
                     spans.append((cid, int(start), int(end)))
                     start = end = res.res_seq
             elif start is not None:
+                assert end is not None
                 spans.append((cid, int(start), int(end)))
                 start = end = None
             prev_seq = res.res_seq
         if start is not None:
+            assert end is not None
             spans.append((cid, int(start), int(end)))
     return spans
 
@@ -644,7 +708,7 @@ def _extract_heuristic(graph: nx.Graph) -> ProteinSemantics | None:
     chains: dict[str, ProteinChainSemantics] = {}
     trace_chains: dict[str, list[int]] = {}
     backbone_indices: set[int] = set()
-    for cid, trace in zip(chain_ids, segments, strict=False):
+    for cid, trace in zip(chain_ids, segments):
         residues = [
             ProteinResidueSemantics(
                 res_name="UNK",
@@ -717,26 +781,39 @@ def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
         for cid, chain_obj in raw_chains.items():
             if not isinstance(chain_obj, dict):
                 continue
-            residues_obj = chain_obj.get("residues", [])
+            chain_data = {str(k): v for k, v in chain_obj.items()}
+            residues_obj = chain_data.get("residues", [])
             residues: list[ProteinResidueSemantics] = []
             if isinstance(residues_obj, list):
                 for r in residues_obj:
                     if not isinstance(r, dict):
                         continue
+                    residue_data = {str(k): v for k, v in r.items()}
+                    atom_indices_raw = residue_data.get("atom_indices", [])
+                    atom_indices: list[int] = []
+                    if isinstance(atom_indices_raw, list):
+                        for x in atom_indices_raw:
+                            if not isinstance(x, (str, bytes, bytearray, SupportsInt, SupportsIndex)):
+                                continue
+                            atom_indices.append(int(x))
+                    ca_index_raw = residue_data.get("ca_index")
+                    c_index_raw = residue_data.get("c_index")
+                    o_index_raw = residue_data.get("o_index")
+                    n_index_raw = residue_data.get("n_index")
                     residues.append(
                         ProteinResidueSemantics(
-                            res_name=str(r.get("res_name", "UNK")),
-                            res_seq=_to_int(r.get("res_seq", 0), 0),
-                            chain_id=str(r.get("chain_id", cid)),
-                            atom_indices=[int(x) for x in r.get("atom_indices", [])],
-                            ca_index=(None if r.get("ca_index") is None else int(r["ca_index"])),
-                            c_index=(None if r.get("c_index") is None else int(r["c_index"])),
-                            o_index=(None if r.get("o_index") is None else int(r["o_index"])),
-                            n_index=(None if r.get("n_index") is None else int(r["n_index"])),
-                            ss_type=_normalize_ss(r.get("ss_type", "C")),
+                            res_name=str(residue_data.get("res_name", "UNK")),
+                            res_seq=_to_int(residue_data.get("res_seq", 0), 0),
+                            chain_id=str(residue_data.get("chain_id", cid)),
+                            atom_indices=atom_indices,
+                            ca_index=(None if ca_index_raw is None else _to_int(ca_index_raw, 0)),
+                            c_index=(None if c_index_raw is None else _to_int(c_index_raw, 0)),
+                            o_index=(None if o_index_raw is None else _to_int(o_index_raw, 0)),
+                            n_index=(None if n_index_raw is None else _to_int(n_index_raw, 0)),
+                            ss_type=_normalize_ss(residue_data.get("ss_type", "C")),
                         )
                     )
-            chains[str(cid)] = ProteinChainSemantics(chain_id=str(chain_obj.get("chain_id", cid)), residues=residues)
+            chains[str(cid)] = ProteinChainSemantics(chain_id=str(chain_data.get("chain_id", cid)), residues=residues)
 
     confidence_raw = str(payload.get("confidence_tier", ProteinConfidenceTier.INSUFFICIENT.value))
     try:
@@ -746,18 +823,18 @@ def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
 
     return ProteinSemantics(
         chains=chains,
-        hetatm_indices={int(x) for x in payload.get("hetatm_indices", [])},
-        backbone_indices={int(x) for x in payload.get("backbone_indices", [])},
-        sidechain_indices={int(x) for x in payload.get("sidechain_indices", [])},
-        helix_spans=[(str(c), int(s), int(e)) for c, s, e in payload.get("helix_spans", [])],
-        sheet_spans=[(str(c), int(s), int(e)) for c, s, e in payload.get("sheet_spans", [])],
-        ligand_indices={int(x) for x in payload.get("ligand_indices", [])},
-        water_indices={int(x) for x in payload.get("water_indices", [])},
-        ion_indices={int(x) for x in payload.get("ion_indices", [])},
+        hetatm_indices=_to_int_set(payload.get("hetatm_indices", [])),
+        backbone_indices=_to_int_set(payload.get("backbone_indices", [])),
+        sidechain_indices=_to_int_set(payload.get("sidechain_indices", [])),
+        helix_spans=_to_spans(payload.get("helix_spans", [])),
+        sheet_spans=_to_spans(payload.get("sheet_spans", [])),
+        ligand_indices=_to_int_set(payload.get("ligand_indices", [])),
+        water_indices=_to_int_set(payload.get("water_indices", [])),
+        ion_indices=_to_int_set(payload.get("ion_indices", [])),
         confidence_tier=confidence,
-        confidence_reasons=[str(x) for x in payload.get("confidence_reasons", [])],
-        provenance=[str(x) for x in payload.get("provenance", [])],
-        trace_chains={str(cid): [int(x) for x in idxs] for cid, idxs in payload.get("trace_chains", {}).items()},
+        confidence_reasons=_to_str_list(payload.get("confidence_reasons", [])),
+        provenance=_to_str_list(payload.get("provenance", [])),
+        trace_chains=_to_trace_chains(payload.get("trace_chains", {})),
     )
 
 

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -131,6 +131,13 @@ def _to_int(value: object, default: int = 0) -> int:
         return default
 
 
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
 def _to_int_set(value: object) -> set[int]:
     if not isinstance(value, list):
         return set()
@@ -538,10 +545,10 @@ def _extract_from_annotations(
     if n_atoms == 0:
         return None
 
-    residues: dict[tuple[str, int, str], list[int]] = {}
-    residue_order: list[tuple[str, int, str]] = []
-    residue_names: dict[tuple[str, int, str], set[str]] = {}
-    residue_ss: dict[tuple[str, int, str], str] = {}
+    residues: dict[tuple[str, int, str, str], list[int]] = {}
+    residue_order: list[tuple[str, int, str, str]] = []
+    residue_names: dict[tuple[str, int, str, str], set[str]] = {}
+    residue_ss: dict[tuple[str, int, str, str], str] = {}
 
     hetatm_indices: set[int] = set()
     ligand_indices: set[int] = set()
@@ -921,7 +928,7 @@ def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
                             n_index=(None if n_index_raw is None else _to_int(n_index_raw, 0)),
                             ss_type=_normalize_ss(residue_data.get("ss_type", "C")),
                             i_code=str(residue_data.get("i_code", "") or ""),
-                            b_factor=float(residue_data.get("b_factor", 0.0) or 0.0),
+                            b_factor=_to_float(residue_data.get("b_factor", 0.0)),
                         )
                     )
             chains[str(cid)] = ProteinChainSemantics(chain_id=str(chain_data.get("chain_id", cid)), residues=residues)

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -105,6 +105,7 @@ class ProteinSemantics:
     confidence_reasons: list[str] = field(default_factory=list)
     provenance: list[str] = field(default_factory=list)
     trace_chains: dict[str, list[int]] = field(default_factory=dict)
+    het_chains: dict[str, set[int]] = field(default_factory=dict)
 
 
 @dataclass
@@ -546,6 +547,11 @@ def _extract_from_annotations(
     ligand_indices: set[int] = set()
     water_indices: set[int] = set()
     ion_indices: set[int] = set()
+    # Non-polymer atoms never join a chain's residue list, so their chain would
+    # otherwise be lost here.  Renderers need it to drop a chain's ligands along
+    # with its ribbon.
+    het_chains: dict[str, set[int]] = {}
+    atom_chain: dict[int, str] = {}
 
     for idx, row in enumerate(annotations):
         rec = str(row["record_type"])
@@ -555,9 +561,11 @@ def _extract_from_annotations(
         res_seq = _to_int(row["res_seq"], default=idx + 1)
         ss_type = _normalize_ss(row["ss_type"])
         i_code = str(row.get("i_code", "") or "")
+        atom_chain[idx] = chain_id
 
         if rec == "HETATM":
             hetatm_indices.add(idx)
+            het_chains.setdefault(chain_id, set()).add(idx)
             if res_name in _WATER_RESNAMES:
                 water_indices.add(idx)
             elif res_name in _ION_RESNAMES:
@@ -608,6 +616,7 @@ def _extract_from_annotations(
 
         has_trace_anchor = ca_index is not None or (n_index is not None and c_index is not None)
         if not has_trace_anchor or not _is_peptide_residue(names, res_name):
+            het_chains.setdefault(chain_id, set()).update(idxs)
             if res_name in _WATER_RESNAMES:
                 water_indices.update(idxs)
             elif res_name in _ION_RESNAMES:
@@ -652,6 +661,15 @@ def _extract_from_annotations(
         if idx in protein_atoms or idx in hetatm_indices or idx in water_indices or idx in ion_indices:
             continue
         ligand_indices.add(idx)
+        het_chains.setdefault(atom_chain.get(idx, "A"), set()).add(idx)
+
+    # Residues that failed the >=2-per-chain continuity test are not polymer as
+    # far as the renderer is concerned; keep them addressable by chain.
+    for cid, residues_list in chains_raw.items():
+        if cid in chains:
+            continue
+        for res in residues_list:
+            het_chains.setdefault(cid, set()).update(res.atom_indices)
 
     trace_chains: dict[str, list[int]] = {}
     for cid, chain in chains.items():
@@ -677,6 +695,7 @@ def _extract_from_annotations(
         confidence_reasons=[f"{provenance} annotations parsed"],
         provenance=[provenance],
         trace_chains=trace_chains,
+        het_chains=het_chains,
     )
     has_ca = any(res.ca_index is not None for chain in chains.values() for res in chain.residues)
     inferred_count = _supplement_secondary_structure(graph, semantics)
@@ -855,6 +874,7 @@ def protein_semantics_to_dict(semantics: ProteinSemantics) -> dict[str, object]:
         "confidence_reasons": list(semantics.confidence_reasons),
         "provenance": list(semantics.provenance),
         "trace_chains": {cid: list(idxs) for cid, idxs in semantics.trace_chains.items()},
+        "het_chains": {cid: sorted(idxs) for cid, idxs in semantics.het_chains.items()},
     }
 
 
@@ -922,6 +942,7 @@ def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
         confidence_reasons=_to_str_list(payload.get("confidence_reasons", [])),
         provenance=_to_str_list(payload.get("provenance", [])),
         trace_chains=_to_trace_chains(payload.get("trace_chains", {})),
+        het_chains={cid: set(idxs) for cid, idxs in _to_trace_chains(payload.get("het_chains", {})).items()},
     )
 
 

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -653,6 +653,10 @@ def _extract_from_annotations(
         return None
 
     protein_atoms = {idx for chain in chains.values() for res in chain.residues for idx in res.atom_indices}
+    # Backbone names are collected before a residue is diverted to ligand, so a
+    # lone amino acid on its own chain left N/CA/C/O behind here -- and renderers
+    # hide backbone atoms, so it vanished instead of drawing as a ligand.
+    backbone_indices &= protein_atoms
     sidechain_indices = protein_atoms - backbone_indices
 
     # In metadata-driven inputs without HETATM annotations (e.g. MOL2), treat

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -37,6 +37,16 @@ _SS_INFERENCE = {
     "sheet_abs_torsion_min": 130.0,
     "sheet_d3_min": 8.0,
     "sheet_d2_min": 6.1,
+    # A beta strand only exists as part of a sheet: an extended residue must
+    # have a partner strand alongside it.  Without this, the extension test
+    # above is satisfied by any extended coil, which is the dominant source of
+    # false strands (and of spurious arrowheads in cartoon renders).
+    # Partner CA within this distance, and at least this far away in sequence
+    # so a residue cannot pair with its own neighbours.
+    "sheet_pair_max_dist": 5.5,
+    "sheet_pair_min_seq_sep": 3,
+    # How far pairing extends along a candidate run from a paired residue.
+    "sheet_pair_propagate": 1,
     "bridge_gap": 1,
     "min_helix_run": 4,
     "min_sheet_run": 3,
@@ -387,6 +397,48 @@ def _infer_missing_ss_in_chain(graph: nx.Graph, residues: list[ProteinResidueSem
         elif sheet_like and not helix_like:
             sheet_votes[i] += 1
             sheet_votes[i + 1] += 1
+
+    # Strand pairing filter.  The extension test above is a single-strand
+    # geometry test, which extended coil also passes; requiring a partner
+    # strand alongside is what makes it specific.  Cheap O(k^2) over strand
+    # candidates only, which is a small fraction of the chain.
+    max_d = _SS_INFERENCE["sheet_pair_max_dist"]
+    min_sep = int(_SS_INFERENCE["sheet_pair_min_seq_sep"])
+    candidates = [i for i in range(n) if sheet_votes[i] > 0 and anchors[i] is not None]
+    paired: set[int] = set()
+    for a_idx, i in enumerate(candidates):
+        if i in paired:
+            continue
+        pi = anchors[i]
+        assert pi is not None
+        for j in candidates[a_idx + 1 :]:
+            if abs(j - i) < min_sep:
+                continue
+            pj = anchors[j]
+            assert pj is not None
+            if _distance(pi, pj) <= max_d:
+                paired.add(i)
+                paired.add(j)
+                break
+    # Pairing is a property of the strand, not of each residue: a residue in
+    # the middle of a paired strand whose own nearest partner is marginally
+    # too far is still strand.  Propagate along runs of strand candidates.
+    # Reach is bounded: extended coil frequently abuts a real strand, so
+    # propagating along the whole candidate run would re-absorb it.
+    cand_set = set(candidates)
+    reach = int(_SS_INFERENCE["sheet_pair_propagate"])
+    for i in sorted(paired):
+        for step in (-1, 1):
+            j = i + step
+            for _ in range(reach):
+                if j not in cand_set:
+                    break
+                paired.add(j)
+                j += step
+
+    for i in range(n):
+        if sheet_votes[i] > 0 and i not in paired:
+            sheet_votes[i] = 0
 
     inferred = ["C"] * n
     for i in range(n):

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -100,7 +100,7 @@ class ProteinSemantics:
     sheet_spans: list[tuple[str, int, int]]
     ligand_indices: set[int] = field(default_factory=set)
     water_indices: set[int] = field(default_factory=set)
-    ion_indices: set[int] = field(default_factory=set)
+    ion_indices: set[int] = field(default_factory=set)  # incl. inorganic counter-ions (SO4/PO4)
     confidence_tier: ProteinConfidenceTier = ProteinConfidenceTier.FULL_RIBBON
     confidence_reasons: list[str] = field(default_factory=list)
     provenance: list[str] = field(default_factory=list)

--- a/src/xyzgraph/protein.py
+++ b/src/xyzgraph/protein.py
@@ -21,6 +21,8 @@ _ANNOTATION_ALIASES: dict[str, tuple[str, ...]] = {
     "res_seq": ("res_seq", "auth_seq_id", "label_seq_id", "residuenumbers"),
     "chain_id": ("chain_id", "auth_asym_id", "label_asym_id", "chainids"),
     "ss_type": ("ss_type", "secondary_structure"),
+    "i_code": ("i_code", "insertion_code", "pdbx_pdb_ins_code", "auth_ins_code"),
+    "b_factor": ("b_factor", "bfactor", "temp_factor", "tempfactor", "b_iso_or_equiv", "plddt"),
 }
 
 _WATER_RESNAMES: frozenset[str] = frozenset({"HOH", "WAT", "DOD", "H2O", "TIP", "TIP3", "SOL"})
@@ -74,6 +76,8 @@ class ProteinResidueSemantics:
     o_index: int | None
     n_index: int | None
     ss_type: str = "C"
+    i_code: str = ""  # PDB insertion code; part of residue identity
+    b_factor: float = 0.0  # temperature factor / AlphaFold pLDDT
 
 
 @dataclass
@@ -215,6 +219,11 @@ def _normalize_annotations(raw: Iterable[dict[str, object]] | None, n_atoms: int
         chain_id = str(_pick_annotation_value(normalized_row, "chain_id", "A")).strip() or "A"
         res_seq = _to_int(_pick_annotation_value(normalized_row, "res_seq", idx + 1), default=idx + 1)
         ss_type = _normalize_ss(_pick_annotation_value(normalized_row, "ss_type", "C"))
+        i_code = str(_pick_annotation_value(normalized_row, "i_code", "") or "").strip()
+        try:
+            b_factor = float(_pick_annotation_value(normalized_row, "b_factor", 0.0))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            b_factor = 0.0
 
         out.append(
             {
@@ -224,10 +233,30 @@ def _normalize_annotations(raw: Iterable[dict[str, object]] | None, n_atoms: int
                 "chain_id": chain_id,
                 "res_seq": res_seq,
                 "ss_type": ss_type,
+                "i_code": i_code,
+                "b_factor": b_factor,
             }
         )
 
     return out
+
+
+def _residue_b_factor(annotations: list[dict[str, object]], idxs: list[int]) -> float:
+    """Per-residue B-factor: the CA value, else the mean over the residue.
+
+    pLDDT is reported on CA, so that atom is preferred where it exists.
+    """
+    vals = []
+    for idx in idxs:
+        row = annotations[idx]
+        try:
+            b = float(row.get("b_factor", 0.0))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if str(row.get("atom_name", "")).upper().strip() == "CA":
+            return b
+        vals.append(b)
+    return sum(vals) / len(vals) if vals else 0.0
 
 
 def _derive_ss_spans(chains: dict[str, ProteinChainSemantics], ss_type: str) -> list[tuple[str, int, int]]:
@@ -525,6 +554,7 @@ def _extract_from_annotations(
         chain_id = str(row["chain_id"]).strip() or "A"
         res_seq = _to_int(row["res_seq"], default=idx + 1)
         ss_type = _normalize_ss(row["ss_type"])
+        i_code = str(row.get("i_code", "") or "")
 
         if rec == "HETATM":
             hetatm_indices.add(idx)
@@ -536,7 +566,7 @@ def _extract_from_annotations(
                 ligand_indices.add(idx)
             continue
 
-        key = (chain_id, int(res_seq), res_name)
+        key = (chain_id, int(res_seq), i_code, res_name)
         if key not in residues:
             residues[key] = []
             residue_order.append(key)
@@ -554,9 +584,10 @@ def _extract_from_annotations(
     backbone_indices: set[int] = set()
     protein_atoms: set[int] = set()
 
-    for chain_id, res_seq, res_name in residue_order:
-        idxs = residues[(chain_id, res_seq, res_name)]
-        names = residue_names[(chain_id, res_seq, res_name)]
+    for key in residue_order:
+        chain_id, res_seq, i_code, res_name = key
+        idxs = residues[key]
+        names = residue_names[key]
 
         ca_index = c_index = o_index = n_index = None
         for idx in idxs:
@@ -594,7 +625,9 @@ def _extract_from_annotations(
             c_index=c_index,
             o_index=o_index,
             n_index=n_index,
-            ss_type=residue_ss[(chain_id, res_seq, res_name)],
+            ss_type=residue_ss[key],
+            i_code=i_code,
+            b_factor=_residue_b_factor(annotations, idxs),
         )
         chains_raw.setdefault(chain_id, []).append(residue)
         protein_atoms.update(idxs)
@@ -863,6 +896,8 @@ def protein_semantics_from_dict(payload: dict[str, object]) -> ProteinSemantics:
                             o_index=(None if o_index_raw is None else _to_int(o_index_raw, 0)),
                             n_index=(None if n_index_raw is None else _to_int(n_index_raw, 0)),
                             ss_type=_normalize_ss(residue_data.get("ss_type", "C")),
+                            i_code=str(residue_data.get("i_code", "") or ""),
+                            b_factor=float(residue_data.get("b_factor", 0.0) or 0.0),
                         )
                     )
             chains[str(cid)] = ProteinChainSemantics(chain_id=str(chain_data.get("chain_id", cid)), residues=residues)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -16,3 +16,8 @@ def test_core_data_present():
     assert "C" not in DATA.metals
     assert DATA.electronegativity["O"] > DATA.electronegativity["C"]
     assert DATA.aromatic_atoms < DATA.conjugatable_atoms
+
+
+def test_sblock_metals_are_classified_as_metals():
+    """s-block selector set remains a true subset of the metals taxonomy."""
+    assert DATA.sblock_metals <= DATA.metals

--- a/tests/test_protein_semantics.py
+++ b/tests/test_protein_semantics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from itertools import pairwise
+from typing import Iterable, Iterator, TypeVar
 
 import networkx as nx
 
@@ -12,6 +12,19 @@ from xyzgraph.protein import (
     annotate_protein_semantics,
     protein_semantics_from_dict,
 )
+
+_T = TypeVar("_T")
+
+
+def _pairwise(iterable: Iterable[_T]) -> Iterator[tuple[_T, _T]]:
+    it = iter(iterable)
+    try:
+        previous = next(it)
+    except StopIteration:
+        return
+    for current in it:
+        yield previous, current
+        previous = current
 
 
 def _add_node(g: nx.Graph, idx: int, sym: str, x: float) -> None:
@@ -236,7 +249,7 @@ def test_heuristic_requires_peptide_links_not_just_ca_like_motifs():
         idx += 4
 
     # Connect motifs as a single large component without carbonyl->amide links.
-    for a, b in pairwise(ca_nodes):
+    for a, b in _pairwise(ca_nodes):
         g.add_edge(a, b)
 
     report = annotate_protein_semantics(g, protein_requested=True)
@@ -271,7 +284,8 @@ def test_geometry_inference_supplements_unlabeled_secondary_structure():
 def test_geometry_inference_preserves_explicit_secondary_structure_labels():
     g, annotations = _build_helical_backbone(n_residues=12)
     for row in annotations:
-        if row["res_seq"] <= 4:
+        res_seq = row.get("res_seq")
+        if isinstance(res_seq, int) and res_seq <= 4:
             row["ss_type"] = "H"
 
     report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")

--- a/tests/test_protein_semantics.py
+++ b/tests/test_protein_semantics.py
@@ -1,0 +1,408 @@
+"""Tests for xyzgraph protein semantics extraction."""
+
+from __future__ import annotations
+
+import math
+
+import networkx as nx
+
+from xyzgraph.protein import (
+    ProteinConfidenceTier,
+    annotate_protein_semantics,
+    protein_semantics_from_dict,
+)
+
+
+def _add_node(g: nx.Graph, idx: int, sym: str, x: float) -> None:
+    g.add_node(idx, symbol=sym, position=(x, 0.0, 0.0))
+
+
+def _build_helical_backbone(n_residues: int = 12) -> tuple[nx.Graph, list[dict[str, object]]]:
+    g = nx.Graph()
+    annotations: list[dict[str, object]] = []
+    serial = 0
+    prev_c: int | None = None
+    for i in range(n_residues):
+        seq = i + 1
+        theta = math.radians(100.0 * i)
+        ca = (2.3 * math.cos(theta), 2.3 * math.sin(theta), 1.5 * i)
+        n_pos = (ca[0] - 1.1, ca[1], ca[2])
+        c_pos = (ca[0] + 1.1, ca[1], ca[2])
+        o_pos = (ca[0] + 1.8, ca[1] + 0.7, ca[2])
+
+        n_idx = serial
+        g.add_node(n_idx, symbol="N", position=n_pos)
+        annotations.append(
+            {"record_type": "ATOM", "atom_name": "N", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+        )
+        serial += 1
+
+        ca_idx = serial
+        g.add_node(ca_idx, symbol="C", position=ca)
+        annotations.append(
+            {
+                "record_type": "ATOM",
+                "atom_name": "CA",
+                "res_name": "ALA",
+                "res_seq": seq,
+                "chain_id": "A",
+                "ss_type": "C",
+            }
+        )
+        serial += 1
+
+        c_idx = serial
+        g.add_node(c_idx, symbol="C", position=c_pos)
+        annotations.append(
+            {"record_type": "ATOM", "atom_name": "C", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+        )
+        serial += 1
+
+        o_idx = serial
+        g.add_node(o_idx, symbol="O", position=o_pos)
+        annotations.append(
+            {"record_type": "ATOM", "atom_name": "O", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+        )
+        serial += 1
+
+        g.add_edges_from([(n_idx, ca_idx), (ca_idx, c_idx), (c_idx, o_idx)])
+        if prev_c is not None:
+            g.add_edge(prev_c, n_idx)
+        prev_c = c_idx
+
+    return g, annotations
+
+
+def test_annotation_extraction_full_ribbon_and_ligand_partition():
+    g = nx.Graph()
+    # Residue 1: N-CA-C-O
+    _add_node(g, 0, "N", 0.0)
+    _add_node(g, 1, "C", 1.0)
+    _add_node(g, 2, "C", 2.0)
+    _add_node(g, 3, "O", 3.0)
+    # Residue 2: N-CA-C-O
+    _add_node(g, 4, "N", 4.0)
+    _add_node(g, 5, "C", 5.0)
+    _add_node(g, 6, "C", 6.0)
+    _add_node(g, 7, "O", 7.0)
+    # Ligand atoms
+    _add_node(g, 8, "C", 9.0)
+    _add_node(g, 9, "O", 10.0)
+
+    g.add_edges_from(
+        [
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (2, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (8, 9),
+        ]
+    )
+
+    annotations = [
+        {"record_type": "ATOM", "atom_name": "N", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "CA", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "C", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "O", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "N", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "CA", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "C", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "H"},
+        {"record_type": "ATOM", "atom_name": "O", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "H"},
+        {
+            "record_type": "HETATM",
+            "atom_name": "C1",
+            "res_name": "LIG",
+            "res_seq": 101,
+            "chain_id": "A",
+            "ss_type": "C",
+        },
+        {
+            "record_type": "HETATM",
+            "atom_name": "O1",
+            "res_name": "LIG",
+            "res_seq": 101,
+            "chain_id": "A",
+            "ss_type": "C",
+        },
+    ]
+
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    assert "A" in report.semantics.chains
+    assert len(report.semantics.chains["A"].residues) == 2
+    assert report.semantics.ligand_indices == {8, 9}
+
+    payload = g.graph["protein_semantics"]
+    sem2 = protein_semantics_from_dict(payload)
+    assert sem2.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    protein_atoms = {i for ch in sem2.chains.values() for r in ch.residues for i in r.atom_indices}
+    assert 8 not in protein_atoms
+    assert 9 not in protein_atoms
+
+
+def test_heuristic_fallback_largest_component_trace_only():
+    g = nx.Graph()
+    # Largest component, peptide-like chain with 3 residues.
+    coords = [
+        ("N", 0.0),
+        ("C", 1.0),
+        ("C", 2.0),
+        ("O", 3.0),
+        ("N", 4.0),
+        ("C", 5.0),
+        ("C", 6.0),
+        ("O", 7.0),
+        ("N", 8.0),
+        ("C", 9.0),
+        ("C", 10.0),
+        ("O", 11.0),
+    ]
+    for i, (sym, x) in enumerate(coords):
+        _add_node(g, i, sym, x)
+    g.add_edges_from(
+        [
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (2, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (6, 8),
+            (8, 9),
+            (9, 10),
+            (10, 11),
+        ]
+    )
+
+    # Separate ligand component.
+    _add_node(g, 12, "C", 20.0)
+    _add_node(g, 13, "O", 21.0)
+    _add_node(g, 14, "N", 22.0)
+    g.add_edges_from([(12, 13), (13, 14)])
+
+    report = annotate_protein_semantics(g, atom_annotations=None, protein_requested=True)
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.TRACE_ONLY
+    assert report.semantics.ligand_indices == {12, 13, 14}
+    assert "A" in report.semantics.trace_chains
+    assert len(report.semantics.trace_chains["A"]) >= 3
+
+
+def test_heuristic_requires_peptide_links_not_just_ca_like_motifs():
+    g = nx.Graph()
+
+    # Build 6 residue-like local motifs without peptide C(=O)-N links:
+    # each "CA" carbon has N and carbonyl neighbors, but CA-CA is linked directly.
+    idx = 0
+    ca_nodes: list[int] = []
+    for _ in range(6):
+        n_atom = idx
+        ca_atom = idx + 1
+        c_atom = idx + 2
+        o_atom = idx + 3
+        _add_node(g, n_atom, "N", float(n_atom))
+        _add_node(g, ca_atom, "C", float(ca_atom))
+        _add_node(g, c_atom, "C", float(c_atom))
+        _add_node(g, o_atom, "O", float(o_atom))
+        g.add_edges_from([(n_atom, ca_atom), (ca_atom, c_atom), (c_atom, o_atom)])
+        ca_nodes.append(ca_atom)
+        idx += 4
+
+    # Connect motifs as a single large component without carbonyl->amide links.
+    for a, b in zip(ca_nodes[:-1], ca_nodes[1:], strict=False):
+        g.add_edge(a, b)
+
+    report = annotate_protein_semantics(g, protein_requested=True)
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.INSUFFICIENT
+    assert report.semantics.chains == {}
+
+
+def test_no_metadata_and_not_requested_returns_none():
+    g = nx.Graph()
+    _add_node(g, 0, "C", 0.0)
+    _add_node(g, 1, "O", 1.0)
+    g.add_edge(0, 1)
+
+    report = annotate_protein_semantics(g, atom_annotations=None, protein_requested=False)
+    assert report is None
+    assert "protein_semantics" not in g.graph
+
+
+def test_geometry_inference_supplements_unlabeled_secondary_structure():
+    g, annotations = _build_helical_backbone(n_residues=12)
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    chain = report.semantics.chains["A"]
+    labels = [res.ss_type for res in chain.residues]
+    assert any(ss in {"H", "E"} for ss in labels)
+    assert any("inferred from geometry" in msg for msg in report.confidence_reasons)
+    assert "inferred" in report.semantics.provenance
+
+
+def test_geometry_inference_preserves_explicit_secondary_structure_labels():
+    g, annotations = _build_helical_backbone(n_residues=12)
+    for row in annotations:
+        if row["res_seq"] <= 4:
+            row["ss_type"] = "H"
+
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")
+    assert report is not None
+    chain = report.semantics.chains["A"]
+    by_seq = {res.res_seq: res.ss_type for res in chain.residues}
+    for seq in range(1, 5):
+        assert by_seq[seq] == "H"
+    assert any("supplemented by geometry inference" in msg for msg in report.confidence_reasons)
+
+
+def test_requested_with_weak_signal_returns_insufficient():
+    g = nx.Graph()
+    for i, sym in enumerate(["C", "N", "O", "H", "C"]):
+        _add_node(g, i, sym, float(i))
+    g.add_edges_from([(0, 1), (1, 2), (2, 3), (3, 4)])
+
+    report = annotate_protein_semantics(g, protein_requested=True)
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.INSUFFICIENT
+    assert report.semantics.chains == {}
+
+
+def test_annotation_alias_keys_are_normalized():
+    g = nx.Graph()
+    for i, (sym, x) in enumerate(
+        [
+            ("N", 0.0),
+            ("C", 1.0),
+            ("C", 2.0),
+            ("O", 3.0),
+            ("N", 4.0),
+            ("C", 5.0),
+            ("C", 6.0),
+            ("O", 7.0),
+        ]
+    ):
+        _add_node(g, i, sym, x)
+    g.add_edges_from([(0, 1), (1, 2), (2, 3), (2, 4), (4, 5), (5, 6), (6, 7)])
+
+    annotations = [
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "N",
+            "auth_comp_id": "ALA",
+            "auth_seq_id": 1,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "CA",
+            "auth_comp_id": "ALA",
+            "auth_seq_id": 1,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "C",
+            "auth_comp_id": "ALA",
+            "auth_seq_id": 1,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "O",
+            "auth_comp_id": "ALA",
+            "auth_seq_id": 1,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "N",
+            "auth_comp_id": "GLY",
+            "auth_seq_id": 2,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "CA",
+            "auth_comp_id": "GLY",
+            "auth_seq_id": 2,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "C",
+            "auth_comp_id": "GLY",
+            "auth_seq_id": 2,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+        {
+            "group_pdb": "ATOM",
+            "auth_atom_id": "O",
+            "auth_comp_id": "GLY",
+            "auth_seq_id": 2,
+            "auth_asym_id": "A",
+            "secondary_structure": "H",
+        },
+    ]
+
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".cif")
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    assert "A" in report.semantics.chains
+    assert len(report.semantics.chains["A"].residues) == 2
+
+
+def test_atom_coded_waters_and_ions_not_forced_to_ligand():
+    g = nx.Graph()
+    for i, (sym, x) in enumerate(
+        [
+            ("N", 0.0),
+            ("C", 1.0),
+            ("C", 2.0),
+            ("O", 3.0),
+            ("N", 4.0),
+            ("C", 5.0),
+            ("C", 6.0),
+            ("O", 7.0),
+            ("O", 12.0),
+            ("H", 13.0),
+            ("H", 14.0),
+            ("NA", 16.0),
+        ]
+    ):
+        _add_node(g, i, sym, x)
+    g.add_edges_from([(0, 1), (1, 2), (2, 3), (2, 4), (4, 5), (5, 6), (6, 7), (8, 9), (8, 10)])
+
+    annotations = [
+        {"record_type": "ATOM", "atom_name": "N", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "CA", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "C", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "O", "res_name": "ALA", "res_seq": 1, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "N", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "CA", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "C", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "O", "res_name": "GLY", "res_seq": 2, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "O", "res_name": "HOH", "res_seq": 3, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "H1", "res_name": "HOH", "res_seq": 3, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "H2", "res_name": "HOH", "res_seq": 3, "chain_id": "A", "ss_type": "C"},
+        {"record_type": "ATOM", "atom_name": "NA", "res_name": "NA", "res_seq": 4, "chain_id": "A", "ss_type": "C"},
+    ]
+
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".cif")
+    assert report is not None
+    assert report.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    assert report.semantics.water_indices == {8, 9, 10}
+    assert report.semantics.ion_indices == {11}
+    assert report.semantics.ligand_indices == set()

--- a/tests/test_protein_semantics.py
+++ b/tests/test_protein_semantics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from itertools import pairwise
 
 import networkx as nx
 
@@ -33,7 +34,14 @@ def _build_helical_backbone(n_residues: int = 12) -> tuple[nx.Graph, list[dict[s
         n_idx = serial
         g.add_node(n_idx, symbol="N", position=n_pos)
         annotations.append(
-            {"record_type": "ATOM", "atom_name": "N", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+            {
+                "record_type": "ATOM",
+                "atom_name": "N",
+                "res_name": "ALA",
+                "res_seq": seq,
+                "chain_id": "A",
+                "ss_type": "C",
+            }
         )
         serial += 1
 
@@ -54,14 +62,28 @@ def _build_helical_backbone(n_residues: int = 12) -> tuple[nx.Graph, list[dict[s
         c_idx = serial
         g.add_node(c_idx, symbol="C", position=c_pos)
         annotations.append(
-            {"record_type": "ATOM", "atom_name": "C", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+            {
+                "record_type": "ATOM",
+                "atom_name": "C",
+                "res_name": "ALA",
+                "res_seq": seq,
+                "chain_id": "A",
+                "ss_type": "C",
+            }
         )
         serial += 1
 
         o_idx = serial
         g.add_node(o_idx, symbol="O", position=o_pos)
         annotations.append(
-            {"record_type": "ATOM", "atom_name": "O", "res_name": "ALA", "res_seq": seq, "chain_id": "A", "ss_type": "C"}
+            {
+                "record_type": "ATOM",
+                "atom_name": "O",
+                "res_name": "ALA",
+                "res_seq": seq,
+                "chain_id": "A",
+                "ss_type": "C",
+            }
         )
         serial += 1
 
@@ -214,7 +236,7 @@ def test_heuristic_requires_peptide_links_not_just_ca_like_motifs():
         idx += 4
 
     # Connect motifs as a single large component without carbonyl->amide links.
-    for a, b in zip(ca_nodes[:-1], ca_nodes[1:], strict=False):
+    for a, b in pairwise(ca_nodes):
         g.add_edge(a, b)
 
     report = annotate_protein_semantics(g, protein_requested=True)

--- a/tests/test_protein_semantics.py
+++ b/tests/test_protein_semantics.py
@@ -207,10 +207,13 @@ def test_annotation_extraction_full_ribbon_and_ligand_partition():
     assert "A" in report.semantics.chains
     assert len(report.semantics.chains["A"].residues) == 2
     assert report.semantics.ligand_indices == {8, 9}
+    # Ligands keep their chain, which is how a renderer drops them with it.
+    assert report.semantics.het_chains == {"A": {8, 9}}
 
     payload = g.graph["protein_semantics"]
     sem2 = protein_semantics_from_dict(payload)
     assert sem2.confidence_tier == ProteinConfidenceTier.FULL_RIBBON
+    assert sem2.het_chains == report.semantics.het_chains
     protein_atoms = {i for ch in sem2.chains.values() for r in ch.residues for i in r.atom_indices}
     assert 8 not in protein_atoms
     assert 9 not in protein_atoms

--- a/tests/test_protein_semantics.py
+++ b/tests/test_protein_semantics.py
@@ -108,6 +108,43 @@ def _build_helical_backbone(n_residues: int = 12) -> tuple[nx.Graph, list[dict[s
     return g, annotations
 
 
+def _build_backbone_from_ca(ca_coords: list[tuple[float, float, float]]) -> tuple[nx.Graph, list[dict[str, object]]]:
+    """Build a peptide backbone graph from an explicit list of CA positions.
+
+    Same node/annotation layout as :func:`_build_helical_backbone`, but the
+    trace is caller-supplied so a test can lay out strands and hairpins.
+    """
+    g = nx.Graph()
+    annotations: list[dict[str, object]] = []
+    serial = 0
+    prev_c: int | None = None
+    for i, ca in enumerate(ca_coords):
+        seq = i + 1
+        n_pos = (ca[0] - 1.1, ca[1], ca[2])
+        c_pos = (ca[0] + 1.1, ca[1], ca[2])
+        o_pos = (ca[0] + 1.8, ca[1] + 0.7, ca[2])
+        idxs = {}
+        for name, sym, pos in (("N", "N", n_pos), ("CA", "C", ca), ("C", "C", c_pos), ("O", "O", o_pos)):
+            g.add_node(serial, symbol=sym, position=pos)
+            annotations.append(
+                {
+                    "record_type": "ATOM",
+                    "atom_name": name,
+                    "res_name": "ALA",
+                    "res_seq": seq,
+                    "chain_id": "A",
+                    "ss_type": "C",
+                }
+            )
+            idxs[name] = serial
+            serial += 1
+        g.add_edges_from([(idxs["N"], idxs["CA"]), (idxs["CA"], idxs["C"]), (idxs["C"], idxs["O"])])
+        if prev_c is not None:
+            g.add_edge(prev_c, idxs["N"])
+        prev_c = idxs["C"]
+    return g, annotations
+
+
 def test_annotation_extraction_full_ribbon_and_ligand_partition():
     g = nx.Graph()
     # Residue 1: N-CA-C-O
@@ -442,3 +479,44 @@ def test_atom_coded_waters_and_ions_not_forced_to_ligand():
     assert report.semantics.water_indices == {8, 9, 10}
     assert report.semantics.ion_indices == {11}
     assert report.semantics.ligand_indices == set()
+
+
+def _extended_chain(n_residues: int, *, second_strand: bool) -> list[tuple[float, float, float]]:
+    """CA positions for an extended strand, optionally paired with a partner.
+
+    A single extended run is indistinguishable from extended coil on the
+    torsion/distance tests alone; only the presence of a partner strand
+    alongside makes it a beta sheet.
+    """
+    rise = 3.3  # CA-CA rise along an extended strand
+    out = [(i * rise, 0.15 * (-1) ** i, 0.0) for i in range(n_residues)]
+    if second_strand:
+        # Antiparallel partner ~4.8 A away, joined by a short turn.
+        out += [(3.0, 2.0, 2.4), (0.5, 2.6, 4.0)]  # turn
+        out += [((n_residues - 1 - i) * rise, 4.8 + 0.15 * (-1) ** i, 0.0) for i in range(n_residues)]
+    return out
+
+
+def test_lone_extended_run_is_not_called_a_strand():
+    """An unpaired extended run is coil, not a beta strand.
+
+    Guards the strand-pairing filter.  Without it the extension test is
+    satisfied by any extended coil, which is the dominant source of false
+    strands -- and of spurious arrowheads in cartoon renders.
+    """
+    coords = _extended_chain(10, second_strand=False)
+    g, annotations = _build_backbone_from_ca(coords)
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")
+    assert report is not None
+    labels = [r.ss_type for r in report.semantics.chains["A"].residues]
+    assert "E" not in labels, f"unpaired extended run called strand: {labels}"
+
+
+def test_paired_extended_runs_are_called_strands():
+    """A hairpin -- two extended runs alongside each other -- is a sheet."""
+    coords = _extended_chain(10, second_strand=True)
+    g, annotations = _build_backbone_from_ca(coords)
+    report = annotate_protein_semantics(g, atom_annotations=annotations, format_hint=".pdb")
+    assert report is not None
+    labels = [r.ss_type for r in report.semantics.chains["A"].residues]
+    assert labels.count("E") >= 6, f"paired strands not detected: {labels}"

--- a/uv.lock
+++ b/uv.lock
@@ -1805,7 +1805,7 @@ source = { git = "https://github.com/jensengroup/xyz2mol_tm.git#532e1196f53fa86a
 
 [[package]]
 name = "xyzgraph"
-version = "1.6.14"
+version = "1.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Adds reusable protein semantics extraction for polymer chains, residues, backbone and side-chain atoms, ligands, waters, ions, modified residues, insertion codes, and B-factors.

This is the prerequisite for aligfellow/xyzrender#96. As such, the package version will need to be reassessed in xyzrender if this feature is to be included.