### PR TITLE
Support variable-sized XYZ trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,14 @@ print(graph_to_ascii(G_cheminf, scale=3.0, include_h=False))
 **Multi-frame trajectory files**:
 
 ```python
-from xyzgraph import read_xyz_file, build_graph
+from xyzgraph import build_graph, read_xyz_file, read_xyz_frames
 
 # Read specific frame from trajectory
 atoms = read_xyz_file("trajectory.xyz", frame=2)
 G = build_graph(atoms, charge=0)
 
-# Process all frames
-from xyzgraph import count_frames_and_atoms
-num_frames, _ = count_frames_and_atoms("trajectory.xyz")
-for i in range(num_frames):
-    atoms = read_xyz_file("trajectory.xyz", frame=i)
+# Process all frames; each record may have its own atom-count header
+for atoms in read_xyz_frames("trajectory.xyz"):
     G = build_graph(atoms, charge=0)
     # ... analyze G
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xyzgraph"
-version = "1.6.14"
+version = "1.6.15"
 description = "Molecular Graph Construction from Cartesian Coordinates."
 authors = [{name = "Alister S. Goodfellow"}]
 readme = "README.md"

--- a/src/xyzgraph/__init__.py
+++ b/src/xyzgraph/__init__.py
@@ -20,7 +20,7 @@ from .graph_builders_xtb import build_graph_xtb
 from .nci import NCIAnalyzer, NCIThresholds, detect_ncis
 from .orca_parser import OrcaParseError, parse_orca_output
 from .stereo import StereoSummary, annotate_stereo
-from .utils import count_frames_and_atoms, graph_debug_report, graph_to_dict, read_xyz_file
+from .utils import count_frames_and_atoms, graph_debug_report, graph_to_dict, read_xyz_file, read_xyz_frames
 
 __all__ = [
     "DATA",
@@ -43,4 +43,5 @@ __all__ = [
     "graph_to_dict",
     "parse_orca_output",
     "read_xyz_file",
+    "read_xyz_frames",
 ]

--- a/src/xyzgraph/cli.py
+++ b/src/xyzgraph/cli.py
@@ -12,7 +12,7 @@ from . import (
     compare_with_rdkit,
     graph_debug_report,
     graph_to_ascii,
-    read_xyz_file,
+    read_xyz_frames,
 )
 from .config import DEFAULT_PARAMS
 from .graph_builders import compute_metadata
@@ -512,16 +512,17 @@ def main():
         stereo=args.stereo,
     )
 
-    # Determine frames to process
-    from .utils import count_frames_and_atoms
-
-    num_frames, _ = count_frames_and_atoms(args.input_file)
+    # Parse once so each trajectory record can use its own atom-count header.
+    xyz_frames = read_xyz_frames(args.input_file, bohr_units=args.bohr)
+    num_frames = len(xyz_frames)
 
     if args.all_frames:
         frames_to_process = list(range(num_frames))
         print_header(args.input_file, metadata, frame_info=f"0-{num_frames - 1}")
         print(f"# Processing all {num_frames} frames from trajectory file...\n")
     else:
+        if args.frame < 0 or args.frame >= num_frames:
+            raise ValueError(f"Frame {args.frame} out of range. File has {num_frames} frame(s).")
         # Show frame info if multi-frame file
         frame_info = args.frame if num_frames > 1 else None
         print_header(args.input_file, metadata, frame_info=frame_info)
@@ -535,7 +536,7 @@ def main():
             print(f"{'=' * 80}\n")
 
         # Build primary graph (cheminf or xtb)
-        atoms = read_xyz_file(args.input_file, bohr_units=args.bohr, frame=frame_idx)
+        atoms = xyz_frames[frame_idx]
         print(f"# Building {args.method} graph from {args.input_file}...")
         G_primary = build_graph(
             atoms=atoms,

--- a/src/xyzgraph/utils.py
+++ b/src/xyzgraph/utils.py
@@ -368,58 +368,81 @@ def count_frames_and_atoms(filepath: str) -> tuple[int, int]:
         num_atoms = int(lines[0].strip())
     except ValueError:
         raise ValueError("Invalid XYZ format: first line should be atom count") from None
+    if num_atoms < 0:
+        raise ValueError("Invalid XYZ format: atom count must be non-negative")
 
     frame_size = num_atoms + 2
+    frame_count = 0
+    line_index = 0
+    while line_index < len(lines):
+        try:
+            frame_atoms = int(lines[line_index].strip())
+        except ValueError:
+            raise ValueError(f"Invalid XYZ format: frame {frame_count} should start with an atom count") from None
+        if frame_atoms != num_atoms:
+            raise ValueError(
+                "Variable atom counts are not supported by count_frames_and_atoms; use read_xyz_frames instead"
+            )
+        if line_index + frame_size > len(lines):
+            raise ValueError(f"File has {len(lines)} lines, not evenly divisible by frame size {frame_size}")
+        frame_count += 1
+        line_index += frame_size
 
-    if len(lines) % frame_size != 0:
-        raise ValueError(f"File has {len(lines)} lines, not evenly divisible by frame size {frame_size}")
-
-    return len(lines) // frame_size, num_atoms
+    return frame_count, num_atoms
 
 
-def read_xyz_file(
-    filepath: str, bohr_units: bool = False, frame: int = 0
-) -> List[Tuple[str, Tuple[float, float, float]]]:
-    """Read XYZ file and return list of (symbol, (x, y, z)) for specified frame.
+def read_xyz_frames(filepath: str, bohr_units: bool = False) -> List[List[Tuple[str, Tuple[float, float, float]]]]:
+    """Read every frame from an XYZ file.
 
-    Supports single and multi-frame (trajectory) files. Streams to requested frame.
+    Each frame is parsed using its own atom-count header and returned in the
+    same ``(symbol, (x, y, z))`` atom-list shape as :func:`read_xyz_file`.
     """
-    num_frames, num_atoms = count_frames_and_atoms(filepath)
-
-    if frame < 0 or frame >= num_frames:
-        raise ValueError(f"Frame {frame} out of range. File has {num_frames} frame(s).")
-
-    start_line = frame * (num_atoms + 2)
-
     with open(filepath, "r") as f:
-        for _ in range(start_line):
-            f.readline()
-        f.readline()  # Skip header
-        f.readline()  # Skip comment
+        lines = f.read().splitlines()
 
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        raise ValueError("Empty XYZ file")
+
+    frames = []
+    line_index = 0
+    frame_index = 0
+    while line_index < len(lines):
+        try:
+            num_atoms = int(lines[line_index].strip())
+        except ValueError:
+            raise ValueError(f"Frame {frame_index}: expected atom count at line {line_index + 1}") from None
+        if num_atoms < 0:
+            raise ValueError(f"Frame {frame_index}: atom count must be non-negative")
+        if line_index + 1 >= len(lines):
+            raise ValueError(f"Frame {frame_index}: missing comment line")
+
+        line_index += 2
         atoms = []
-        for i in range(num_atoms):
-            parts = f.readline().strip().split()
+        for atom_index in range(num_atoms):
+            if line_index >= len(lines):
+                raise ValueError(f"Frame {frame_index} truncated: expected {num_atoms} atoms, found {atom_index}")
+            parts = lines[line_index].strip().split()
             if len(parts) < 4:
-                raise ValueError(f"Frame {frame}, atom {i}: expected at least 4 columns")
+                raise ValueError(f"Frame {frame_index}, atom {atom_index}: expected at least 4 columns")
 
             elem = parts[0]
             try:
                 x, y, z = map(float, parts[1:4])
             except ValueError as e:
-                raise ValueError(f"Frame {frame}, atom {i}: invalid coordinates") from e
+                raise ValueError(f"Frame {frame_index}, atom {atom_index}: invalid coordinates") from e
 
-            # Convert atomic number to symbol if needed
             if elem.isdigit():
                 atomic_num = int(elem)
                 if atomic_num not in DATA.n2s:
-                    raise ValueError(f"Frame {frame}, atom {i}: unknown atomic number {atomic_num}")
+                    raise ValueError(f"Frame {frame_index}, atom {atom_index}: unknown atomic number {atomic_num}")
                 symbol = DATA.n2s[atomic_num]
             else:
                 symbol = elem
 
             if symbol not in DATA.s2n:
-                raise ValueError(f"Frame {frame}, atom {i}: unknown element symbol '{symbol}'")
+                raise ValueError(f"Frame {frame_index}, atom {atom_index}: unknown element symbol '{symbol}'")
 
             if bohr_units:
                 x, y, z = (
@@ -429,8 +452,26 @@ def read_xyz_file(
                 )
 
             atoms.append((symbol, (x, y, z)))
+            line_index += 1
 
-    return atoms
+        frames.append(atoms)
+        frame_index += 1
+
+    return frames
+
+
+def read_xyz_file(
+    filepath: str, bohr_units: bool = False, frame: int = 0
+) -> List[Tuple[str, Tuple[float, float, float]]]:
+    """Read XYZ file and return list of (symbol, (x, y, z)) for specified frame.
+
+    Supports single and multi-frame (trajectory) files.
+    """
+    frames = read_xyz_frames(filepath, bohr_units=bohr_units)
+
+    if frame < 0 or frame >= len(frames):
+        raise ValueError(f"Frame {frame} out of range. File has {len(frames)} frame(s).")
+    return frames[frame]
 
 
 def _parse_pairs(arg_value: str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 """Tests for utility functions."""
 
 import networkx as nx
+import pytest
 
+from xyzgraph import count_frames_and_atoms, read_xyz_file, read_xyz_frames
 from xyzgraph.utils import smallest_rings
 
 
@@ -29,3 +31,67 @@ def test_smallest_rings_azulene_topology():
     G.add_edges_from([(0, 5), (5, 6), (6, 7), (7, 8), (8, 9), (9, 4)])
     sizes = sorted(len(r) for r in smallest_rings(G))
     assert sizes == [5, 7]
+
+
+def test_read_xyz_frames_uniform_trajectory(tmp_path):
+    xyz_file = tmp_path / "uniform.xyz"
+    xyz_file.write_text(
+        "2\nframe 0\nH 0 0 0\n8 1 0 0\n2\nframe 1\nH 0 1 0\nO 1 1 0\n",
+        encoding="utf-8",
+    )
+
+    assert read_xyz_frames(str(xyz_file)) == [
+        [("H", (0.0, 0.0, 0.0)), ("O", (1.0, 0.0, 0.0))],
+        [("H", (0.0, 1.0, 0.0)), ("O", (1.0, 1.0, 0.0))],
+    ]
+    assert count_frames_and_atoms(str(xyz_file)) == (2, 2)
+
+
+def test_read_xyz_frames_variable_atom_counts(tmp_path):
+    xyz_file = tmp_path / "variable.xyz"
+    xyz_file.write_text(
+        "2\nframe 0\nH 0 0 0\nH 1 0 0\n"
+        "3\nframe 1\nH 0 1 0\nO 1 1 0\nH 2 1 0\n"
+        "2\nframe 2\nH 0 2 0\nH 1 2 0\n"
+        "2\nframe 3\nH 0 3 0\nH 1 3 0\n",
+        encoding="utf-8",
+    )
+
+    frames = read_xyz_frames(str(xyz_file))
+
+    assert [len(frame) for frame in frames] == [2, 3, 2, 2]
+    with pytest.raises(ValueError, match="read_xyz_frames"):
+        count_frames_and_atoms(str(xyz_file))
+
+
+def test_read_xyz_file_selects_frame_after_atom_count_change(tmp_path):
+    xyz_file = tmp_path / "variable.xyz"
+    xyz_file.write_text(
+        "2\nframe 0\nH 0 0 0\nH 1 0 0\n3\nframe 1\nH 0 1 0\nO 1 1 0\nH 2 1 0\n2\nframe 2\nC 0 2 0\nO 1 2 0\n",
+        encoding="utf-8",
+    )
+
+    assert read_xyz_file(str(xyz_file), frame=2) == [
+        ("C", (0.0, 2.0, 0.0)),
+        ("O", (1.0, 2.0, 0.0)),
+    ]
+
+
+def test_read_xyz_frames_rejects_truncated_frame(tmp_path):
+    xyz_file = tmp_path / "truncated.xyz"
+    xyz_file.write_text(
+        "2\nframe 0\nH 0 0 0\nH 1 0 0\n3\nframe 1\nH 0 1 0\nO 1 1 0\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"Frame 1 truncated: expected 3 atoms, found 2"):
+        read_xyz_frames(str(xyz_file))
+
+
+def test_count_frames_and_atoms_rejects_negative_atom_count(tmp_path):
+    """Malformed negative counts must fail rather than stalling frame iteration."""
+    xyz_file = tmp_path / "negative.xyz"
+    xyz_file.write_text("-2\ninvalid\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="atom count must be non-negative"):
+        count_frames_and_atoms(str(xyz_file))

--- a/uv.lock
+++ b/uv.lock
@@ -1805,7 +1805,7 @@ source = { git = "https://github.com/jensengroup/xyz2mol_tm.git#532e1196f53fa86a
 
 [[package]]
 name = "xyzgraph"
-version = "1.6.14"
+version = "1.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Adds a frame reader that respects each XYZ record's atom-count header. Existing frame selection and CLI paths now use the same parser, while the legacy frame-count helper remains strict for uniform trajectories.

Prerequisite for aligfellow/xyzrender#171.
